### PR TITLE
fix: Find docker on remote host in deploy workflow (#8)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,8 +94,12 @@ jobs:
 
           # 운영 호스트에서 태그 변경 후 pull/up.
           # DEPLOY_PATH 에 이미 docker-compose.yml + .env 가 놓여 있어야 함.
+          #
+          # 비대화식 SSH 쉘은 /etc/profile 을 로드하지 않아 docker 가 들어있는
+          # /usr/local/bin 이 PATH 에 없을 수 있음. 먼저 PATH 를 보강.
           ssh -p "$DEPLOY_PORT" -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" \
-            "cd '$DEPLOY_PATH' && \
+            "export PATH=/usr/local/bin:/usr/local/sbin:\$PATH && \
+             cd '$DEPLOY_PATH' && \
              if grep -q '^APP_IMAGE_TAG=' .env; then \
                sed -i 's|^APP_IMAGE_TAG=.*|APP_IMAGE_TAG=${IMAGE_TAG}|' .env; \
              else \


### PR DESCRIPTION
## Summary
`v0.3.0` deploy failed at the SSH step with `sh: docker: command not found`. On the remote host, `docker` lives at `/usr/local/bin/docker`, but non-interactive SSH shells do not source `/etc/profile`, so `/usr/local/bin` is missing from `PATH` and the docker symlink is unreachable.

## Change
Prepend `/usr/local/bin:/usr/local/sbin` to `PATH` at the start of the SSH command block in `.github/workflows/deploy.yml`. One-line behavioral addition, no other changes.

## Verification plan
1. Merge this into `main`.
2. Tag `v0.3.1`.
3. The `deploy.yml` workflow triggers; deploy job should now resolve `docker compose pull && up -d` and bring the stack up.
4. Back-merge `main` → `develop` so future tag deploys stay fixed.

Fixes #8