### PR TITLE
feat: Wrap single-shot pipeline in a LangGraph entry point (#19)

### DIFF
--- a/AI_Chat/settings.py
+++ b/AI_Chat/settings.py
@@ -56,6 +56,12 @@ ALLOWED_HOSTS = _env_list('DJANGO_ALLOWED_HOSTS', ['*'] if DEBUG else [])
 # 스킴 포함 전체 URL 로 지정 (예: https://your-domain.example).
 CSRF_TRUSTED_ORIGINS = _env_list('DJANGO_CSRF_TRUSTED_ORIGINS', [])
 
+# 채팅 파이프라인을 LangGraph 기반 진입점으로 실행할지 여부 (2.0.0 Phase 2).
+# 기본 True — dev/운영 모두 새 경로로 운영해 이슈를 조기에 발견.
+# 운영에서 문제 발생 시 .env 에 USE_LANGGRAPH_PIPELINE=False 만 설정하고 재기동하면
+# 이전 direct 호출 경로로 즉시 롤백된다. Phase 3 에서 feature flag 는 제거 예정.
+USE_LANGGRAPH_PIPELINE = _env_bool('USE_LANGGRAPH_PIPELINE', True)
+
 
 # Application definition
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ DB는 Docker Compose가 자동으로 기동·연결하므로 **기본 사용엔 
 - 검색 임계값·캐시 기준 튜닝: `chat/services/query_pipeline.py` 상단 상수.
 - 허용 파일 형식 확장: `files/services/extractor.py`에 새 `_extract_xxx` 함수 추가 + `bo/views/files.py::ALLOWED_EXTS` 갱신.
 - 프롬프트 문구 수정: `assets/prompts/chat/*.md` 를 직접 편집하거나, BO `Prompt 관리` 페이지(`/bo/prompts/`)에서 수정. 운영에서는 `PROMPTS_DIR` 환경변수로 외부 마운트 경로에 프롬프트를 두면 재배포 없이 교체 가능.
+- 채팅 실행 경로 on/off: `USE_LANGGRAPH_PIPELINE` 환경변수. 기본 `True` 로 LangGraph 기반 `chat/graph/app.run_chat_graph` 를 타고, 문제 시 `False` 로 재기동하면 기존 `answer_question()` direct 호출 경로로 즉시 회귀 가능.
 
 ---
 
@@ -414,3 +415,4 @@ DB는 Docker Compose가 자동으로 기동·연결하므로 **기본 사용엔 
 |2026.04.22| 프로덕션 배포 파이프라인 구축<br>태그 푸시 시 GitHub Actions → GHCR → 운영 호스트 자동 배포 |[2026-04-22-deploy.md](resources/documents/2026-04-22-deploy.md)|
 |2026.04.23| 프로덕션 배포 핫픽스 시리즈<br>v0.3.1~v0.3.3: SSH PATH · 컨테이너 GID · /media/ 서빙 |[2026-04-23-deploy-hotfixes.md](resources/documents/2026-04-23-deploy-hotfixes.md)|
 |2026.04.23| 2.0.0 Phase 1 — Prompt 관리 분리<br>프롬프트를 파일로 외부화 + Prompt Loader + BO 편집 페이지 |[2026-04-23-phase1-prompt.md](resources/documents/2026-04-23-phase1-prompt.md)|
+|2026.04.23| 2.0.0 Phase 2 — LangGraph 적용<br>진입점을 `router → single_shot` 그래프로 전환 + `USE_LANGGRAPH_PIPELINE` 플래그 |[2026-04-23-phase2-langgraph.md](resources/documents/2026-04-23-phase2-langgraph.md)|

--- a/chat/graph/__init__.py
+++ b/chat/graph/__init__.py
@@ -1,0 +1,5 @@
+"""LangGraph 기반 채팅 파이프라인.
+
+외부에서는 app.run_chat_graph 만 호출한다.
+state / node 는 내부 구현 세부이며 필요할 때만 직접 import.
+"""

--- a/chat/graph/app.py
+++ b/chat/graph/app.py
@@ -1,0 +1,59 @@
+"""컴파일된 LangGraph 와 외부 진입 함수.
+
+view / service 는 오직 run_chat_graph(question, history) 만 쓴다. state 구조나
+node 구성이 바뀌어도 이 함수의 시그니처·반환·예외는 고정이다 (Phase 3 이후에도).
+
+현재 graph shape:
+    START → router → (conditional on state.route) → single_shot → END
+"""
+
+from functools import lru_cache
+
+from langgraph.graph import END, START, StateGraph
+
+from chat.graph.nodes.router import router_node
+from chat.graph.nodes.single_shot import single_shot_node
+from chat.graph.state import GraphState
+from chat.services.query_pipeline import QueryPipelineError, QueryResult
+
+
+@lru_cache(maxsize=1)
+def _compiled_graph():
+    """프로세스당 한 번만 compile. runserver/gunicorn 프로세스 교체 시 자연 리셋."""
+    builder = StateGraph(GraphState)
+    builder.add_node('router', router_node)
+    builder.add_node('single_shot', single_shot_node)
+
+    builder.add_edge(START, 'router')
+    builder.add_conditional_edges(
+        'router',
+        # state.route 값을 그대로 key 로 쓴다. Phase 4 에서 선택지가 늘어날 때
+        # selector 는 건드리지 않고 아래 매핑에 키/노드만 추가하면 된다.
+        lambda state: state['route'],
+        {'single_shot': 'single_shot'},
+    )
+    builder.add_edge('single_shot', END)
+
+    return builder.compile()
+
+
+def run_chat_graph(question: str, history: list[dict]) -> QueryResult:
+    """Phase 2 단일 외부 진입점.
+
+    반환값은 QueryResult 그대로이며, 실패 시 QueryPipelineError 를 raise 한다.
+    view 의 기존 try/except 블록을 그대로 사용할 수 있도록 시그니처를 맞췄다.
+    """
+    final = _compiled_graph().invoke({
+        'question': question,
+        'history': history,
+    })
+
+    # 노드 내부에서 포착된 에러 메시지가 실렸으면 그대로 전파.
+    if final.get('error'):
+        raise QueryPipelineError(final['error'])
+
+    result = final.get('result')
+    if result is None:
+        # 정상 흐름에선 발생하지 않지만, 노드가 result 를 안 채운 상황을 조기에 드러냄.
+        raise QueryPipelineError('graph 가 결과 없이 종료되었습니다.')
+    return result

--- a/chat/graph/nodes/router.py
+++ b/chat/graph/nodes/router.py
@@ -1,0 +1,17 @@
+"""Router node — 실행 경로 선택.
+
+Phase 2 에서는 진짜 분기 로직 없이 항상 'single_shot' 만 반환하는 placeholder 다.
+graph shape 를 Phase 4 이전에 미리 고정해 두기 위한 자리.
+
+Phase 4 에서 확장 예정:
+    - 규칙 기반 1차 판정 (키워드 / 질문 패턴 / 메타 힌트)
+    - 필요 시 저비용 모델 분류 보조
+    - 실패 시 상위 경로(single_shot → workflow → agent) 승급 정책
+"""
+
+from chat.graph.state import GraphState
+
+
+def router_node(state: GraphState) -> dict:
+    """Phase 2: 모든 요청을 single_shot 으로."""
+    return {'route': 'single_shot'}

--- a/chat/graph/nodes/single_shot.py
+++ b/chat/graph/nodes/single_shot.py
@@ -1,0 +1,26 @@
+"""Single-shot node — 기존 query_pipeline.answer_question() 을 graph 안에서 재사용.
+
+Phase 2 에서는 본체를 재작성하지 않는다. answer_question() 은 그대로 두고
+여기선 호출 + 결과·에러를 state 로 옮기는 래퍼 역할만 한다.
+
+Phase 3 에서 answer_question() 을 더 작은 함수들(검색 / 재정렬 / 프롬프트 조립 /
+OpenAI 호출 / 저장)로 쪼개고 node 책임을 재정리할 예정. 그 시점까지 이 노드는
+'호환성 보존' 목적이다.
+"""
+
+from chat.graph.state import GraphState
+from chat.services.query_pipeline import QueryPipelineError, answer_question
+
+
+def single_shot_node(state: GraphState) -> dict:
+    """state.question + state.history → answer_question → state.result 또는 state.error."""
+    try:
+        result = answer_question(
+            state['question'],
+            history=state.get('history', []),
+        )
+    except QueryPipelineError as exc:
+        # pipeline 에서 raise 한 오류만 문자열로 변환해서 state 에 싣는다.
+        # 다른 예외는 의도치 않은 상황이므로 그대로 올려 Django 500 경로로 보낸다.
+        return {'error': str(exc)}
+    return {'result': result}

--- a/chat/graph/state.py
+++ b/chat/graph/state.py
@@ -1,0 +1,36 @@
+"""LangGraph state 스키마.
+
+Phase 2 는 single-shot 한 경로만 의미있게 사용한다. 이후 Phase 4 에서 router 가
+실제 분기를 시작하고, Phase 5~7 에서 workflow / agent 가 붙을 때도 같은 state
+구조 위에 필드를 '추가' 만 한다는 원칙이다. 지금 존재하지 않는 필드를 미리
+선언해 두지는 않는다 — 코드와 문서 양쪽에서 오해를 만들 수 있어서.
+
+TypedDict 를 쓰는 이유:
+    - 추가 의존성 0 (Pydantic 도입 회피)
+    - LangGraph 가 공식 지원하는 가장 가벼운 state 방식
+    - dataclass(QueryResult) 를 Optional 필드로 그대로 담을 수 있음
+      (현재 checkpointer 를 쓰지 않으므로 직렬화 요구 없음)
+
+total=False 로 둬서 호출자가 초기 상태를 구성할 때 result / error 같은
+출력 필드를 생략할 수 있게 한다.
+"""
+
+from typing import Optional, TypedDict
+
+from chat.services.query_pipeline import QueryResult
+
+
+class GraphState(TypedDict, total=False):
+    # ─── 입력 ──────────────────────────────────────────
+    question: str            # 사용자 질문 원문
+    history: list[dict]      # 세션 히스토리 [{'role':..., 'content':...}, ...]
+
+    # ─── router 결과 ──────────────────────────────────
+    route: str               # Phase 2 에서는 'single_shot' 만.
+                             # Phase 4 에서 'workflow' / 'agent' 등 추가 예정.
+
+    # ─── 실행 결과 ────────────────────────────────────
+    result: Optional[QueryResult]
+
+    # ─── 에러 전달 (노드 내부에서 포착한 메시지) ──────
+    error: Optional[str]

--- a/chat/views/message.py
+++ b/chat/views/message.py
@@ -1,8 +1,10 @@
 import json
 
+from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 
+from chat.graph.app import run_chat_graph
 from chat.services.history_service import (
     clear_history, get_history, save_history,
 )
@@ -24,9 +26,14 @@ def message(request):
     # 세션에서 과거 대화 불러오기 (RAG 컨텍스트와 별개)
     history = get_history(request)
 
-    # RAG 파이프라인 실행
+    # RAG 파이프라인 실행.
+    # Phase 2: USE_LANGGRAPH_PIPELINE=True 면 graph 진입점, False 면 기존 direct 호출.
+    # 두 경로 모두 QueryResult 반환 / QueryPipelineError raise 로 시그니처 동일.
     try:
-        result = answer_question(user_text, history=history)
+        if settings.USE_LANGGRAPH_PIPELINE:
+            result = run_chat_graph(user_text, history=history)
+        else:
+            result = answer_question(user_text, history=history)
     except QueryPipelineError as e:
         return JsonResponse({'error': str(e)}, status=502)
 

--- a/env.example.txt
+++ b/env.example.txt
@@ -28,3 +28,8 @@ OPENAI_MODEL=gpt-4o-mini
 # 프롬프트 파일 루트. 기본값은 repo 내부 assets/prompts/.
 # 운영에서 재배포 없이 수정하고 싶으면 외부 마운트 경로로 override.
 # PROMPTS_DIR=/path/to/external/prompts
+
+# ── 2.0.0 Phase 2 — LangGraph ──────────────────────────
+# 채팅 진입점을 LangGraph 기반 graph 로 보낼지 선택. 기본 True.
+# 문제 발생 시 False 로 즉시 구 direct 경로로 fallback.
+# USE_LANGGRAPH_PIPELINE=True

--- a/env.prod.example.txt
+++ b/env.prod.example.txt
@@ -42,3 +42,8 @@ APP_IMAGE_TAG=latest
 # 프롬프트 파일 루트. 기본값은 이미지 내부 /app/assets/prompts/.
 # 재배포 없이 운영 중 프롬프트를 수정하려면 외부 볼륨을 마운트한 경로 지정.
 # PROMPTS_DIR=/volume1/ai_chat/prompts
+
+# ── 2.0.0 Phase 2 — LangGraph ──────────────────────────
+# LangGraph 기반 실행 경로 사용 여부. 기본 True.
+# 운영에서 회귀가 감지되면 False 로 바꿔 재기동하면 구 direct 경로로 즉시 롤백.
+# USE_LANGGRAPH_PIPELINE=True

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-docx>=1.1
 openpyxl>=3.1
 xlrd>=2.0
 tiktoken>=0.7
+langgraph>=0.2

--- a/resources/documents/2026-04-23-phase2-langgraph.md
+++ b/resources/documents/2026-04-23-phase2-langgraph.md
@@ -1,0 +1,200 @@
+# 2026-04-23 개발 로그 — 2.0.0 Phase 2: LangGraph 적용
+
+## 배경
+2.0.0 로드맵의 두 번째 단계. Phase 1 에서 프롬프트는 파일·로더로 분리됐지만, 질문 처리 진입점은 여전히 `chat/views/message.py` 가 `chat/services/query_pipeline.answer_question()` 을 직접 호출하는 구조. 이 상태로 Phase 4 (라우터) · Phase 5~6 (workflow) · Phase 7 (agent) 를 얹으면 view 와 service 에 분기 로직이 쌓여 구조가 빠르게 망가진다.
+
+Phase 2 의 목표는 **기존 동작과 JSON 응답 포맷을 한 줄도 바꾸지 않고, 실행 진입점을 LangGraph 런타임 위로 옮기는 것**. `answer_question()` 본체는 재사용만 하고, 그 주변에 `state / node / app` 골격을 세운다.
+
+핵심 제약:
+- 응답 품질·포맷·히스토리 동작 **회귀 0** 이 성공 기준
+- LangChain / LangSmith 는 **도입하지 않음**. `langgraph` 단일 패키지만
+- `query_pipeline.py`, `prompt_builder.py`, `history_service.py`, 검색·재정렬은 **이번 단계에서 건드리지 않음**
+
+---
+
+## 1. 패키지 구조
+
+```
+chat/
+  graph/
+    __init__.py
+    state.py        ← GraphState (TypedDict, total=False)
+    app.py          ← _compiled_graph() + run_chat_graph()
+    nodes/
+      __init__.py
+      router.py     ← placeholder, 항상 single_shot
+      single_shot.py← answer_question() 래퍼
+```
+
+`chat/services/` 쪽은 Phase 2 에서 변경 없음.
+
+---
+
+## 2. State 설계
+
+TypedDict 로 가볍게. Pydantic 도입 회피. `total=False` 로 초기화 시 출력 필드 생략 가능.
+
+```python
+class GraphState(TypedDict, total=False):
+    question: str
+    history: list[dict]
+    route: str            # 현재 'single_shot' 만. Phase 4 확장 예정.
+    result: Optional[QueryResult]
+    error: Optional[str]
+```
+
+결정 이유:
+- 추가 의존성 0
+- `QueryResult` dataclass 를 Optional 로 그대로 담을 수 있음 (checkpointer 미사용이라 직렬화 불필요)
+- 향후 workflow/agent 전용 필드는 그때 추가 — Phase 2 에서 미리 선언 안 함
+
+---
+
+## 3. Graph 구성
+
+```
+START → router → (conditional on state.route) → single_shot → END
+```
+
+### router_node
+```python
+def router_node(state: GraphState) -> dict:
+    return {'route': 'single_shot'}
+```
+
+Phase 2 의 실제 역할은 없지만 node 자리만 만들어 둬서 Phase 4 에서 graph shape 를 건드리지 않고 내부 로직만 교체 가능.
+
+### single_shot_node
+```python
+def single_shot_node(state: GraphState) -> dict:
+    try:
+        result = answer_question(state['question'], history=state.get('history', []))
+    except QueryPipelineError as exc:
+        return {'error': str(exc)}
+    return {'result': result}
+```
+
+`QueryPipelineError` 만 state.error 로 변환. 그 외 예외는 올라가 Django 500 경로로.
+
+### 조건부 edge
+```python
+builder.add_conditional_edges(
+    'router',
+    lambda state: state['route'],
+    {'single_shot': 'single_shot'},
+)
+```
+
+Phase 4 에서 매핑에 `'workflow'`, `'agent'` 키를 추가하는 것만으로 확장 — graph 를 다시 짤 필요 없음.
+
+### 컴파일 캐시
+```python
+@lru_cache(maxsize=1)
+def _compiled_graph(): ...
+```
+
+프로세스당 한 번만 `compile()`. runserver / gunicorn 재기동 시 자연 리셋.
+
+---
+
+## 4. 외부 API
+
+view / service 는 오직 `run_chat_graph(question, history)` 만 쓴다.
+
+```python
+def run_chat_graph(question: str, history: list[dict]) -> QueryResult:
+    final = _compiled_graph().invoke({'question': question, 'history': history})
+    if final.get('error'):
+        raise QueryPipelineError(final['error'])
+    result = final.get('result')
+    if result is None:
+        raise QueryPipelineError('graph 가 결과 없이 종료되었습니다.')
+    return result
+```
+
+- 반환 / 예외 시그니처를 **기존 `answer_question()` 과 동일**하게 맞춰 view 의 try/except 블록은 변경 없음.
+
+---
+
+## 5. Feature flag
+
+```python
+# AI_Chat/settings.py
+USE_LANGGRAPH_PIPELINE = _env_bool('USE_LANGGRAPH_PIPELINE', True)
+```
+
+- 기본값 **True** — dev/운영 모두 새 경로로 굴려 Phase 3 에 이미 굳어진 상태로 입장
+- 운영 문제 발생 시 `.env` 에 `USE_LANGGRAPH_PIPELINE=False` 설정 + 재기동 → 즉시 구 direct 경로로 fallback
+- Phase 3 에서 이 flag 제거 예정
+
+view 에서 flag 분기:
+```python
+if settings.USE_LANGGRAPH_PIPELINE:
+    result = run_chat_graph(user_text, history=history)
+else:
+    result = answer_question(user_text, history=history)
+```
+
+history load·save 는 view 에 그대로 — graph 가 Django session 에 결합되는 것을 피함.
+
+---
+
+## 6. 검증
+
+### 자동 smoke (dev 컨테이너)
+- `docker compose exec web python manage.py check` → OK
+- `from langgraph.graph import StateGraph, START, END` import OK (langgraph 1.1.9)
+- `_compiled_graph().nodes` → `['__start__', 'router', 'single_shot']`
+- `run_chat_graph('그냥 안녕?', [])` → `QueryResult(reply='회사 자료에 해당 정보가 없습니다.', ...)` — 기존 no-sources 가드 동작 유지
+- Django test client `POST /message/` → `{reply, sources, chat_log_id}` 키로 200 응답
+
+### 브라우저 회귀
+- [x] 자료 있는 질문 → 기존과 동일한 tone/sources/feedback
+- [x] 자료 없는 질문 → "회사 자료에 해당 정보가 없습니다" + 출처·피드백 버튼 없음
+- [x] 다중 턴 대화 → 히스토리 반영
+- [x] [초기화] 버튼 동작
+- [x] `USE_LANGGRAPH_PIPELINE=False` 로 재기동 → direct 경로에서 동일 응답 포맷 확인 후 원복
+
+---
+
+## 7. 리스크 대응 기록
+
+| 리스크 | 대응 |
+|---|---|
+| LangGraph 의존성 무게 | `langgraph>=0.2` 만 추가, LangChain/LangSmith 미도입. 실제 설치 결과 `langgraph==1.1.9` |
+| 노드 예외가 state 로 포착되지 않음 | `single_shot_node` 에서 `QueryPipelineError` 만 문자열화해 state.error 로 싣고, 다른 예외는 Django 500 경로로 올림 |
+| compiled graph stale | `@lru_cache(maxsize=1)` + runserver/gunicorn 재기동 주기가 자연스러운 리셋 |
+| flag 제거 누락 | Phase 3 issue 본문에 "flag 제거" 태스크 명시 예정 |
+
+---
+
+## 8. 변경 파일 요약
+
+### 신규 (7)
+- `chat/graph/__init__.py`
+- `chat/graph/state.py`
+- `chat/graph/app.py`
+- `chat/graph/nodes/__init__.py`
+- `chat/graph/nodes/router.py`
+- `chat/graph/nodes/single_shot.py`
+- `resources/documents/2026-04-23-phase2-langgraph.md` (본 문서)
+
+### 수정 (5)
+- `requirements.txt` — `langgraph>=0.2`
+- `AI_Chat/settings.py` — `USE_LANGGRAPH_PIPELINE`
+- `env.example.txt` / `env.prod.example.txt` — 플래그 override 주석
+- `chat/views/message.py` — graph / direct 분기
+- `README.md` — 확장 포인트 + 개발 로그 행
+
+### 삭제 (없음)
+`query_pipeline.py` · 검색·재정렬 로직은 전부 유지.
+
+---
+
+## 9. Phase 3 에 넘길 것
+
+- feature flag 제거 (direct 경로 삭제)
+- `answer_question()` 분해 + graph-native 노드로 책임 재배치 (검색 / 재정렬 / 프롬프트 조립 / OpenAI 호출 / 저장 분리)
+- view / graph 경계 재정리 (history 저장 위치, 예외 처리, 응답 후처리)
+
+Phase 4 에서 router 의 실제 분기 로직이 이 구조 위에 올라옴.

--- a/resources/plans/2.0.0_Phase 2_LangGraph_적용_개발_설계.md
+++ b/resources/plans/2.0.0_Phase 2_LangGraph_적용_개발_설계.md
@@ -1,0 +1,550 @@
+# 2.0.0 Phase 2 LangGraph 적용 개발 설계
+
+## 1. 목적
+
+Phase 2의 목적은 현재 Django 기반 챗봇의 실행 진입점을 `LangGraph` 기반 구조로 옮기고, 기존 single-shot 동작을 유지한 채 이후 `single-shot / workflow / agent` 3분류 확장을 위한 실행 프레임을 먼저 확보하는 것이다.
+
+이 단계의 핵심 목표는 아래 4가지다.
+
+1. 현재 질문 처리 진입점을 LangGraph graph 실행 구조로 전환한다.
+2. 기존 `answer_question()` 기반 single-shot 로직을 안전하게 graph node로 래핑한다.
+3. 이후 workflow와 agent를 붙일 수 있는 state와 graph 골격을 만든다.
+4. 현재 서비스 응답 품질과 JSON 응답 포맷을 최대한 유지한다.
+
+---
+
+## 2. 현재 상태
+
+현재 질문 처리 흐름은 아래와 같다.
+
+- `chat/views/message.py`
+  - 요청 수신
+  - 히스토리 로드
+  - `answer_question()` 직접 호출
+  - 응답 저장
+
+- `chat/services/query_pipeline.py`
+  - 문서 검색
+  - Canonical QA 검색
+  - 프롬프트 조립
+  - OpenAI 1회 호출
+  - ChatLog/TokenUsage 저장
+
+즉 현재 구조는 `view -> single-shot pipeline` 직접 호출 구조이며, 실행 흐름을 분기하거나 상태를 별도 관리하는 레이어가 없다.
+
+이 구조의 한계는 다음과 같다.
+
+- 실행 흐름이 graph나 state로 표현되지 않는다.
+- 앞으로 workflow/agent를 추가하면 view나 service가 비대해질 가능성이 높다.
+- 이후 프레임워크가 더 잘하는 orchestration 영역과 서비스 고유 로직이 섞여 있다.
+
+---
+
+## 3. 이번 Phase의 범위
+
+이번 Phase에서는 아래까지만 한다.
+
+- LangGraph 의존성 도입
+- graph package 구조 설계
+- 최소 state 정의
+- 기존 single-shot 파이프라인을 호출하는 node 작성
+- graph 진입점 구성
+- view에서 graph 실행으로 연결
+- 필요 시 feature flag 또는 안전 전환 장치 설계
+
+이번 Phase에서 하지 않는 것:
+
+- 실제 workflow 로직 구현
+- 실제 agent loop 구현
+- 정교한 3분류 라우터 구현
+- LangChain 도입
+- LangSmith 도입
+- 기존 검색/재정렬/계산 로직의 본격적인 분해
+
+즉, 이 단계는 `기존 기능 유지 상태에서 LangGraph 런타임으로 진입점을 교체하는 단계`다.
+
+---
+
+## 4. 설계 원칙
+
+### 4-1. 기존 single-shot 품질을 깨지 않는다
+
+Phase 2에서 가장 중요한 원칙은 현재 답변 품질을 최대한 유지하는 것이다.
+
+따라서 이 단계에서는 기존 `answer_question()`을 바로 해체하지 않고, graph node 안에서 호출하는 방식으로 먼저 옮긴다.
+
+즉,
+
+- 지금은 `직접 호출`
+- Phase 2에서는 `graph node 안에서 래핑 호출`
+
+구조로 바뀐다.
+
+### 4-2. LangGraph는 실행 구조를 담당한다
+
+이 단계에서 LangGraph가 맡는 것은 아래와 같다.
+
+- state 전달
+- node 실행
+- 시작점/종료점 정의
+- 향후 분기 확장을 위한 골격 제공
+
+반대로 아래는 아직 기존 구현을 유지한다.
+
+- 문서 검색
+- rerank
+- QA 검색
+- OpenAI 호출
+- 응답 후처리
+
+### 4-3. 최초 graph는 작고 단순해야 한다
+
+처음부터 복잡한 multi-node graph를 만들지 않는다.
+
+Phase 2의 최소 목표는 아래 둘 중 하나다.
+
+1. `START -> single_shot -> END`
+2. `START -> route -> single_shot -> END`
+
+권장 방향은 2번이다.
+
+이유:
+
+- Phase 4에서 라우터를 붙이기 쉬움
+- 현재는 route node가 항상 `single_shot`만 반환하게 단순화 가능
+- 그래프 구조를 너무 늦게 바꾸지 않아도 됨
+
+### 4-4. 프레임워크가 대체할 부분과 남길 부분을 구분한다
+
+Phase 2에서는 아래를 명확히 구분해야 한다.
+
+프레임워크가 주로 담당할 영역:
+
+- graph state
+- node transition
+- route field
+- 실행 진입점
+
+우리 코드로 남길 영역:
+
+- `answer_question()`
+- 검색 함수
+- DB 접근
+- QueryResult
+- history 저장 방식
+
+즉 Phase 2는 `모든 걸 graph-native로 재작성`이 아니라, `orchestration을 graph로 옮기는 첫 단계`다.
+
+### 4-5. LangChain 없이 시작한다
+
+현재 결정 기준에 따라 Phase 2에서는 `LangGraph only`로 간다.
+
+즉,
+
+- LangGraph 사용
+- LangChain 미도입
+- LangSmith 미도입
+
+으로 정리한다.
+
+이유:
+
+- 실행 구조가 우선 과제임
+- LangChain 도입 없이도 충분히 graph 구조를 만들 수 있음
+- 추상화가 늘어나기 전에 실행 구조를 먼저 안정화하는 것이 목적에 맞음
+
+---
+
+## 5. 목표 패키지 구조
+
+권장 초기 구조는 아래와 같다.
+
+```text
+chat/
+  graph/
+    __init__.py
+    app.py
+    state.py
+    nodes/
+      __init__.py
+      router.py
+      single_shot.py
+```
+
+설명:
+
+- `state.py`
+  - graph state 정의
+
+- `nodes/router.py`
+  - 현재는 placeholder 성격
+  - 일단 `single_shot`만 반환
+  - 나중에 Phase 4에서 실제 라우터로 확장
+
+- `nodes/single_shot.py`
+  - 기존 `answer_question()` 호출 래퍼
+
+- `app.py`
+  - graph 생성/compile
+
+현재 `chat/services/query_pipeline.py`는 유지한다.
+
+---
+
+## 6. Graph 구조 설계
+
+### 6-1. 최소 구조
+
+권장 최소 graph 구조:
+
+```text
+START
+  -> router
+  -> single_shot
+END
+```
+
+현재 router는 아래처럼 동작한다.
+
+- 항상 `route = "single_shot"` 설정
+- 이후 Phase 4에서 실제 분기 로직으로 확장
+
+### 6-2. 왜 router를 미리 두는가
+
+Phase 2에서는 실제 라우팅 로직이 없더라도 router node를 미리 두는 것이 좋다.
+
+이유:
+
+- graph shape가 이후에도 크게 안 바뀜
+- Phase 4에서 graph 전체를 다시 흔들 필요가 줄어듦
+- 현재는 매우 단순한 placeholder로 둘 수 있음
+
+---
+
+## 7. State 설계
+
+### 7-1. 최소 state 필드
+
+Phase 2에서 권장하는 최소 state는 아래와 같다.
+
+- `question`
+  - 사용자 질문 원문
+- `history`
+  - 세션 히스토리
+- `route`
+  - 현재 선택된 처리 경로
+- `result`
+  - `QueryResult` 또는 이에 준하는 응답 객체
+- `error`
+  - 오류 메시지 또는 예외 정보
+
+예상 개념:
+
+```python
+{
+    "question": str,
+    "history": list,
+    "route": "single_shot",
+    "result": QueryResult | None,
+    "error": str | None,
+}
+```
+
+### 7-2. state 설계 원칙
+
+- Phase 2에서는 단순해야 한다.
+- 아직 workflow/agent 전용 필드는 넣지 않아도 된다.
+- 다만 `route`는 미리 둔다.
+- 향후 확장을 막는 구조는 피한다.
+
+---
+
+## 8. Node 설계
+
+### 8-1. Router Node
+
+역할:
+
+- state에 `route`를 기록
+- 현재는 항상 `single_shot` 반환
+
+Phase 2에서의 성격:
+
+- placeholder
+- 실제 분기 판단은 하지 않음
+
+향후 확장:
+
+- 규칙 기반 라우터
+- 모델 기반 보조 라우터
+- 실패 시 승급 규칙
+
+### 8-2. Single Shot Node
+
+역할:
+
+- 기존 `answer_question(question, history)` 호출
+- 결과를 state에 기록
+
+이 단계의 핵심:
+
+- 기존 query pipeline을 그대로 재사용
+- node는 래퍼 역할만 수행
+
+이 방식의 장점:
+
+- 현재 동작 유지
+- 리스크 최소화
+- 이후 Phase 3에서 점진 분해 가능
+
+---
+
+## 9. View 연결 방식
+
+현재 `chat/views/message.py`는 `answer_question()`을 직접 호출하고 있다.
+
+Phase 2 이후 목표는 아래와 같다.
+
+- view는 더 이상 `answer_question()`을 직접 부르지 않는다.
+- 대신 `graph.invoke(initial_state)`를 호출한다.
+- 최종 응답은 state의 `result`에서 꺼낸다.
+
+즉 view 역할은 아래로 단순화된다.
+
+- 요청 파싱
+- history 로드
+- initial state 구성
+- graph invoke
+- result 반환
+- history 저장
+
+중요:
+
+- 응답 JSON 포맷은 최대한 그대로 유지한다.
+- 프론트엔드와 BO 연동 포맷을 깨지 않는 것이 우선이다.
+
+---
+
+## 10. 안전 전환 전략
+
+Phase 2는 구조 전환 성격이 강하므로, 가능하면 안전 장치를 두는 것이 좋다.
+
+권장 옵션:
+
+- feature flag 기반 전환
+- 또는 작은 브랜치 단위로 순차 적용
+
+예시 방향:
+
+- `USE_LANGGRAPH_PIPELINE=true/false`
+
+이 설정이 있으면:
+
+- `false`: 기존 direct pipeline 유지
+- `true`: graph invoke 경로 사용
+
+이 방식의 장점:
+
+- 문제 발생 시 빠른 롤백 가능
+- 리팩토링 검증에 유리
+
+Phase 2 문서 관점에서는 feature flag를 권장 옵션으로 둔다.
+
+---
+
+## 11. 코드 적용 대상
+
+### 11-1. 신규 생성 대상
+
+- `chat/graph/__init__.py`
+- `chat/graph/app.py`
+- `chat/graph/state.py`
+- `chat/graph/nodes/__init__.py`
+- `chat/graph/nodes/router.py`
+- `chat/graph/nodes/single_shot.py`
+
+### 11-2. 직접 수정 대상
+
+- `chat/views/message.py`
+  - direct pipeline 호출 제거
+  - graph invoke 연결
+
+- `AI_Chat/settings.py` 또는 별도 설정 위치
+  - 필요 시 feature flag 추가
+
+### 11-3. 유지 대상
+
+- `chat/services/query_pipeline.py`
+- `chat/services/prompt_builder.py`
+- `chat/services/history_service.py`
+- 검색 관련 서비스
+
+즉 이 단계에서 기존 핵심 서비스는 최대한 유지한다.
+
+---
+
+## 12. 세부 개발 순서
+
+### Step 1. LangGraph 도입 준비
+
+할 일:
+
+- LangGraph 의존성 추가
+- 초기 graph 패키지 구조 생성
+
+완료 기준:
+
+- graph 관련 코드 파일을 둘 구조가 준비됨
+
+### Step 2. State 정의
+
+할 일:
+
+- 최소 state 필드 정의
+- 초기 입력 스키마 정리
+
+완료 기준:
+
+- view와 node가 공유할 공통 state 구조가 정해짐
+
+### Step 3. Router Node 초안 작성
+
+할 일:
+
+- placeholder router node 작성
+- 현재는 `single_shot`만 선택하도록 단순화
+
+완료 기준:
+
+- graph가 향후 3분류 확장을 고려한 shape를 가짐
+
+### Step 4. Single Shot Node 작성
+
+할 일:
+
+- 기존 `answer_question()` 호출 래퍼 작성
+- result/error를 state에 기록
+
+완료 기준:
+
+- graph node 내부에서 기존 single-shot 실행 가능
+
+### Step 5. Graph App 구성
+
+할 일:
+
+- node 연결
+- graph compile
+- invoke 진입점 함수 정리
+
+완료 기준:
+
+- 외부에서 호출 가능한 graph 실행 진입점 확보
+
+### Step 6. View 연결
+
+할 일:
+
+- `message.py`에서 graph invoke 연결
+- 기존 응답 JSON 포맷 유지
+
+완료 기준:
+
+- 실제 요청 흐름이 graph를 통해 수행됨
+
+### Step 7. 안전 전환 장치 적용
+
+할 일:
+
+- feature flag 도입 여부 결정
+- 필요 시 direct path fallback 유지
+
+완료 기준:
+
+- 운영 반영 시 리스크를 줄일 수 있는 최소 장치 확보
+
+### Step 8. 회귀 점검
+
+할 일:
+
+- 기존 single-shot 질문셋 실행
+- 응답 JSON 비교
+- no-source 케이스 확인
+- history 저장 동작 확인
+
+완료 기준:
+
+- LangGraph 적용 후에도 기존 동작이 유지됨
+
+---
+
+## 13. 예상 위험 요소
+
+### 13-1. graph 적용 후 기능은 같지만 구조만 복잡해 보일 수 있음
+
+위험:
+
+- 아직 workflow/agent가 없으므로 Phase 2만 보면 이득이 작아 보일 수 있다.
+
+대응:
+
+- Phase 2의 목적은 기능 확장이 아니라 실행 구조 전환임을 명시
+- 이후 Phase 4~7의 기반 단계로 본다
+
+### 13-2. 기존 코드와 graph 코드가 중복될 수 있음
+
+위험:
+
+- direct path와 graph path가 동시에 남으면 임시 중복이 생길 수 있다.
+
+대응:
+
+- 임시 중복은 허용하되, Phase 3에서 정리 대상으로 명확히 표기
+
+### 13-3. view와 graph의 책임 경계가 애매해질 수 있음
+
+위험:
+
+- history 저장, 예외 처리, 응답 후처리 위치가 섞일 수 있다.
+
+대응:
+
+- Phase 2에서는 최소 변경 원칙 유지
+- 책임 경계 재정리는 Phase 3에서 본격 수행
+
+### 13-4. 너무 이른 graph-native 재작성 시도
+
+위험:
+
+- Phase 2에서 기존 query pipeline을 과도하게 분해하면 일정과 리스크가 커진다.
+
+대응:
+
+- 이 단계에서는 래핑 우선
+- 점진 치환은 Phase 3로 넘긴다
+
+---
+
+## 14. 완료 정의
+
+Phase 2는 아래 조건을 만족하면 완료로 본다.
+
+- LangGraph가 프로젝트 실행 구조에 도입되었다.
+- 질문 요청이 graph invoke 경로를 통해 처리된다.
+- 기존 `answer_question()`은 single_shot node 내부에서 재사용된다.
+- 응답 JSON 포맷이 유지된다.
+- 현재 single-shot 품질이 유지된다.
+- 향후 `single-shot / workflow / agent` 분기를 추가할 graph 골격이 준비된다.
+
+---
+
+## 15. Phase 2 완료 후 다음 단계 연결
+
+Phase 2가 끝나면 다음 단계인 `기존 코드 개편`에서 아래 작업을 더 자연스럽게 진행할 수 있다.
+
+- direct orchestration 제거
+- node 책임 세분화
+- graph-native 구조로의 점진 치환
+- workflow/agent 확장 시 진입점 재사용
+
+즉 Phase 2는 단순히 LangGraph를 붙이는 것이 아니라, `현재 서비스를 graph 런타임 위로 안전하게 올리는 전환 단계`로 본다.

--- a/resources/plans/detail/2.0.0_Phase 2_LangGraph_적용_개발_플랜.md
+++ b/resources/plans/detail/2.0.0_Phase 2_LangGraph_적용_개발_플랜.md
@@ -1,0 +1,363 @@
+# 2.0.0 Phase 2 — LangGraph 적용 개발 플랜
+
+## Context
+
+Phase 1 에서 프롬프트가 파일과 로더로 분리됐지만, 질문 처리 진입점은 여전히 `chat/views/message.py` → `chat/services/query_pipeline.answer_question()` 직접 호출 구조다. 이 상태로 `workflow` / `agent` 경로를 덧붙이면 view 와 service 에 분기 로직이 쌓여서 구조가 빠르게 망가진다.
+
+Phase 2 의 목표는 **기존 single-shot 동작과 JSON 응답 포맷을 그대로 유지한 채, 실행 진입점을 LangGraph 기반으로 옮기는 것**이다. 이 단계에서는 `answer_question()` 자체를 해체하지 않고 `single_shot` 노드가 그대로 호출한다. 대신 graph / state / node / 진입점(`app`) 골격을 만들어 둬서, Phase 4 (라우터) · Phase 5~6 (workflow) · Phase 7 (agent) 가 같은 graph 위에 노드를 추가하기만 하면 되게 한다.
+
+핵심 제약:
+- 응답 품질·포맷·히스토리 동작 **회귀 0** 가 성공 기준.
+- LangChain / LangSmith 는 **도입하지 않는다.** `langgraph` 단일 패키지만.
+- `query_pipeline.py`, `prompt_builder.py`, `history_service.py`, 검색·재정렬 서비스는 **이번 단계에서 건드리지 않는다.**
+
+---
+
+## Scope
+
+**포함**
+- `langgraph` 의존성 추가
+- `chat/graph/` 패키지 골격 (`app.py`, `state.py`, `nodes/router.py`, `nodes/single_shot.py`)
+- 최소 state: `question`, `history`, `route`, `result`, `error`
+- 2-노드 graph: `START → router → (conditional) → single_shot → END`
+- `USE_LANGGRAPH_PIPELINE` feature flag (기본 True)
+- `chat/views/message.py` 에서 flag 분기해 graph 또는 direct 호출
+- 회귀 검증 체크리스트
+
+**제외 (이후 Phase)**
+- 실제 라우팅 로직 (Phase 4)
+- workflow / agent 노드 실체 (Phase 5~7)
+- `answer_question()` 분해·node 책임 세분화 (Phase 3)
+- LangChain / LangSmith
+- graph persistence / checkpointer
+
+---
+
+## git-flow 계획
+
+- **Milestone**: `Phase 4: 2.0.0 Refactoring` (이미 존재, 그대로 사용)
+- **Issue**: `feat: Wrap single-shot pipeline in a LangGraph entry point`
+  - 라벨: `type: feature` / `priority: medium` / `status: in-progress`
+  - Closes 로 연결
+- **Branch**: `feature/#N-langgraph-integration` (N = 새 이슈 번호), develop 에서 분기
+- **PR 분할**: Phase 2 전체를 **한 PR**로 진행. state / node / view 연결이 서로 의존해서 분할 시 중간 커밋이 깨진 상태로 남음. 커밋은 8개 스텝 단위로 쪼개 히스토리 가독성 유지.
+
+> **배포 정책**: 2.0.0 완료 전까지 develop → main PR 과 버전 태그는 사용자가 명시 지시할 때만 실행. Phase 2 머지 후 "정기 배포" 제안 금지.
+
+---
+
+## 핵심 설계 결정
+
+### state 타입: `TypedDict`
+Pydantic 모델 대신 `TypedDict` 를 쓴다. 이유:
+- 추가 의존성 0
+- LangGraph 가 공식 지원하는 가장 가벼운 방식
+- `QueryResult` dataclass 를 `Optional[QueryResult]` 로 그대로 담을 수 있음 (직렬화 불필요 — checkpointer 안 씀)
+
+### 분기 구조: `add_conditional_edges`
+router → single_shot 를 "단순 edge" 가 아니라 `add_conditional_edges` 로 연결한다. 이유:
+- Phase 4 에서 `workflow`, `agent` 분기가 추가될 때 graph shape 를 건드리지 않고 매핑만 확장 가능
+- 라우터가 `state["route"]` 값을 그대로 반환하는 selector 한 줄이면 됨
+
+```python
+graph.add_conditional_edges(
+    'router',
+    lambda state: state['route'],
+    {'single_shot': 'single_shot'},   # Phase 4에서 'workflow', 'agent' 추가
+)
+```
+
+### 예외 처리: 노드 내부 try/except → state.error
+`QueryPipelineError` 를 `single_shot` 노드 안에서 잡아 `state["error"]` 로 저장하고, view 에서 그 값을 보고 502 를 돌린다. graph 외부로 예외가 올라오면 LangGraph 내부 트레이스가 섞여서 원래 에러 메시지를 가릴 수 있어 노드에서 잡는다.
+
+### Feature flag: 기본 True
+`USE_LANGGRAPH_PIPELINE=True` 를 기본값으로. 운영에 깔린 이미지가 문제가 생기면 `.env` 에서 `False` 만 설정해 재시작하면 즉시 구 경로로 회귀. dev·운영 모두 새 경로로 굴려 Phase 3 로 넘어갈 때 이미 굳어진 상태로 들어간다.
+
+### 히스토리 저장 위치: view 유지
+history load·save 는 `chat/views/message.py` 에 그대로 둔다. graph 안으로 끌어들이지 않는다. 이유:
+- Django session 접근을 node 에서 하면 graph 가 Django 에 결합됨
+- 노드는 "질문 + 이전 history" 를 받아 결과만 돌려주는 순수 함수에 가깝게 유지
+- Phase 3 에서 정리할 때 경계가 분명
+
+---
+
+## 구현 순서 (8 steps / 8 commits)
+
+### Step 1 — `langgraph` 의존성 + 패키지 골격
+**할 일**
+- `requirements.txt` 에 `langgraph>=0.2` 추가
+- 빈 패키지 디렉토리 생성:
+  - `chat/graph/__init__.py`
+  - `chat/graph/nodes/__init__.py`
+- 컨테이너 재빌드해서 import 성공 확인:
+  ```
+  docker compose build web && docker compose up -d
+  docker compose exec -T web python -c "import langgraph; from langgraph.graph import StateGraph, START, END; print('ok')"
+  ```
+
+**커밋**: `chore: Add langgraph dependency and chat/graph/ package skeleton (#N)`
+
+### Step 2 — State 정의 (`chat/graph/state.py`)
+```python
+from typing import TypedDict, Optional
+from chat.services.query_pipeline import QueryResult
+
+class GraphState(TypedDict, total=False):
+    # 입력
+    question: str
+    history: list[dict]
+
+    # router 결과
+    route: str           # 'single_shot' 만 사용 (Phase 4에서 확장)
+
+    # 실행 결과
+    result: Optional[QueryResult]
+
+    # 에러 전달 (노드 내부에서 포착)
+    error: Optional[str]
+```
+
+- `total=False` 로 둬서 view 가 초기 상태를 만들 때 `result` / `error` 는 생략 가능.
+- 주석으로 "Phase 4 확장 시 route enum 등 추가 예정" 명시.
+
+**커밋**: `feat: Define LangGraph state schema for chat pipeline (#N)`
+
+### Step 3 — Router 노드 (`chat/graph/nodes/router.py`)
+```python
+from chat.graph.state import GraphState
+
+def router_node(state: GraphState) -> dict:
+    """실행 경로 결정. Phase 2 에서는 항상 single_shot."""
+    return {'route': 'single_shot'}
+```
+
+**추가 주석**: Phase 4 에서 규칙 기반 판정 → 필요 시 저비용 모델 분류로 확장할 자리임을 docstring 에 명시.
+
+**커밋**: `feat: Add placeholder router node always selecting single_shot (#N)`
+
+### Step 4 — Single Shot 노드 (`chat/graph/nodes/single_shot.py`)
+```python
+from chat.graph.state import GraphState
+from chat.services.query_pipeline import QueryPipelineError, answer_question
+
+def single_shot_node(state: GraphState) -> dict:
+    """기존 answer_question() 을 graph 안에서 재사용."""
+    try:
+        result = answer_question(
+            state['question'],
+            history=state.get('history', []),
+        )
+    except QueryPipelineError as exc:
+        return {'error': str(exc)}
+    return {'result': result}
+```
+
+- 예외는 **여기서만** 문자열로 변환. view 는 state 만 본다.
+- 성공 시 `result` 에만 값 기록, 실패 시 `error` 에만 값 기록 — 둘이 동시에 존재하지 않도록.
+
+**커밋**: `feat: Add single_shot node wrapping answer_question (#N)`
+
+### Step 5 — Graph 조립 (`chat/graph/app.py`)
+```python
+from functools import lru_cache
+from langgraph.graph import StateGraph, START, END
+
+from chat.graph.nodes.router import router_node
+from chat.graph.nodes.single_shot import single_shot_node
+from chat.graph.state import GraphState
+from chat.services.query_pipeline import QueryPipelineError, QueryResult
+
+
+@lru_cache(maxsize=1)
+def _compiled_graph():
+    builder = StateGraph(GraphState)
+    builder.add_node('router', router_node)
+    builder.add_node('single_shot', single_shot_node)
+    builder.add_edge(START, 'router')
+    builder.add_conditional_edges(
+        'router',
+        lambda state: state['route'],
+        {'single_shot': 'single_shot'},
+    )
+    builder.add_edge('single_shot', END)
+    return builder.compile()
+
+
+def run_chat_graph(question: str, history: list[dict]) -> QueryResult:
+    """외부에서 호출하는 단일 진입점. QueryResult 를 돌려주거나 QueryPipelineError 를 raise."""
+    final = _compiled_graph().invoke({
+        'question': question,
+        'history': history,
+    })
+    if final.get('error'):
+        raise QueryPipelineError(final['error'])
+    result = final.get('result')
+    if result is None:
+        raise QueryPipelineError('graph 가 결과 없이 종료되었습니다.')
+    return result
+```
+
+- `@lru_cache(maxsize=1)` 로 최초 호출 시만 compile (매 요청 compile 방지).
+- 외부 API 는 오직 `run_chat_graph` 하나 — Phase 3 에서 이 시그니처가 그대로 인터페이스가 됨.
+- `QueryPipelineError` 로 통일해서 view 변경 최소화.
+
+**커밋**: `feat: Compile chat graph with router → single_shot edges (#N)`
+
+### Step 6 — settings / env: feature flag
+**`AI_Chat/settings.py`** 하단에 추가:
+```python
+# LangGraph 기반 실행 경로 사용 여부. Phase 2 기본값 True.
+# 문제 발생 시 .env 에서 False 로 설정해 즉시 구 direct 경로로 fallback 가능.
+USE_LANGGRAPH_PIPELINE = _env_bool('USE_LANGGRAPH_PIPELINE', True)
+```
+
+**`env.example.txt` / `env.prod.example.txt`** 에 override 주석 추가:
+```
+# Phase 2 LangGraph 진입. 기본 True, 문제 시 False 로 즉시 롤백 가능.
+# USE_LANGGRAPH_PIPELINE=True
+```
+
+**커밋**: `feat: Add USE_LANGGRAPH_PIPELINE flag with documented override (#N)`
+
+### Step 7 — View 연결 (`chat/views/message.py`)
+`message()` 만 수정. `reset()` 은 그대로.
+
+```python
+# 상단 import 추가
+from django.conf import settings
+from chat.graph.app import run_chat_graph
+
+# 기존 try 블록 교체
+try:
+    if settings.USE_LANGGRAPH_PIPELINE:
+        result = run_chat_graph(user_text, history=history)
+    else:
+        result = answer_question(user_text, history=history)
+except QueryPipelineError as e:
+    return JsonResponse({'error': str(e)}, status=502)
+```
+
+- 나머지 로직(history append / save / JSON 응답) **완전 동일** 하게 유지.
+- 두 경로 모두 `QueryResult` 를 돌려주므로 아래 코드는 수정 불필요.
+
+**커밋**: `feat: Route chat requests through LangGraph when flag is on (#N)`
+
+### Step 8 — 회귀 검증 + 문서
+**검증 (아래 Verification 섹션)**
+- 자동 smoke
+- 브라우저 수동
+
+**문서**
+- `README.md` 섹션 10-3 확장 포인트에 한 줄 추가:
+  ```
+  - LangGraph 실행 경로 on/off: `USE_LANGGRAPH_PIPELINE` env.
+  ```
+- `README.md` 섹션 11 개발 로그에 새 행 + `resources/documents/2026-04-YY-phase2-langgraph.md` 링크
+- `resources/documents/2026-04-YY-phase2-langgraph.md` 작성 (Phase 1 dev log 와 같은 형식)
+
+**커밋**: `docs: Document LangGraph entry point and Phase 2 flag (#N)`
+
+---
+
+## 파일 변경 요약
+
+### 신규 (7)
+```
+chat/graph/__init__.py
+chat/graph/state.py
+chat/graph/app.py
+chat/graph/nodes/__init__.py
+chat/graph/nodes/router.py
+chat/graph/nodes/single_shot.py
+resources/documents/2026-04-YY-phase2-langgraph.md
+```
+
+### 수정 (5)
+```
+requirements.txt                # langgraph>=0.2
+AI_Chat/settings.py             # USE_LANGGRAPH_PIPELINE
+env.example.txt                 # flag 주석
+env.prod.example.txt            # flag 주석
+chat/views/message.py           # graph/direct 분기
+README.md                       # 확장 포인트 + 개발 로그
+```
+
+### 삭제 (없음)
+`chat/services/query_pipeline.py` 를 포함해 기존 서비스는 그대로 유지.
+
+---
+
+## 주요 파일 경로 (reference)
+
+**현재 코드 흐름** (Phase 2 전)
+- `chat/urls.py`:8 → `chat.views.message.message`
+- `chat/views/message.py`:29 → `answer_question(user_text, history=history)` 직접 호출
+- `chat/services/query_pipeline.py:82` → `answer_question()` 본체 (그대로 유지)
+- `chat/services/history_service.py` → `get_history()` / `save_history()` (그대로 유지)
+
+**재사용 대상**
+- `QueryResult` dataclass — state 의 `result` 필드 타입
+- `QueryPipelineError` — graph 래퍼가 그대로 던짐 → view 의 기존 except 블록 변경 없음
+- `_env_bool()` (settings.py 의 헬퍼) — flag 파싱에 재사용
+- Phase 1 의 `prompt_loader` — 본 단계에서 건드릴 일은 없지만 향후 node 에서 그대로 호출 가능
+
+---
+
+## 검증 (end-to-end)
+
+### 자동 smoke (dev 컨테이너)
+```bash
+# 빌드 + import 확인
+docker compose build web
+docker compose up -d
+docker compose exec -T web python manage.py check
+
+# graph 단독 호출 smoke
+docker compose exec -T web python manage.py shell -c "
+from chat.graph.app import run_chat_graph
+r = run_chat_graph('테스트', [])
+print(type(r).__name__, '|', 'reply_len=', len(r.reply))
+"
+
+# 환경 스위치 smoke
+#   True: graph 경로 타야 함
+#   False: direct 경로여도 동일 응답 포맷
+```
+
+### 브라우저 회귀 (flag=True)
+- [ ] `/` 접속 → 채팅 UI 정상
+- [ ] 자료 있는 질문 한 건 → 기존과 같은 reply, sources 배지, 피드백 버튼 표시
+- [ ] 자료 없는 질문 한 건 → `회사 자료에 해당 정보가 없습니다` 응답, 출처·피드백 버튼 없음
+- [ ] 다중 턴 대화 → 이전 대화 맥락이 다음 응답에 반영됨 (history 저장·로드 동작)
+- [ ] `[초기화]` 버튼 → 이전 대화 초기화 후 첫 인사 복구
+
+### 브라우저 비교 (flag=False)
+- [ ] `.env` 에 `USE_LANGGRAPH_PIPELINE=False` 설정 + 컨테이너 재기동
+- [ ] 같은 질문 재실행 → 응답 JSON 포맷 동일, reply 품질 동일(모델은 `temperature=0` 이므로 동일 질문엔 거의 동일 답 기대)
+- [ ] 확인 후 `True` 로 원복
+
+### 에러 경로
+- [ ] `OPENAI_API_KEY` 를 임시로 비우고 요청 → 502 에러 메시지가 view 를 통해 JSON 으로 돌아옴 (`QueryPipelineError` 전파 경로 확인). 확인 후 키 원복.
+
+---
+
+## 리스크 & 대응
+
+| 리스크 | 대응 |
+|---|---|
+| LangGraph 패키지가 추가 의존성(`langchain-core`, `pydantic` 등)을 끌고 와 이미지 용량이 늘어남 | `requirements.txt` 변경 후 `pip install` 결과를 확인. 문제 없으면 수용. 필요 시 `langgraph` 대신 `langgraph-core` 만 찝어 고정. |
+| graph 내부에서 예외가 나 state 에 저장되지 않고 올라옴 | `single_shot_node` 에서 `QueryPipelineError` 포착 → `error` 필드 기록. 다른 예외는 올라오게 두되 view 의 500 일반 핸들러가 받음. |
+| `@lru_cache` 로 compile 된 graph 가 테스트/개발 중 stale 상태 | dev 는 runserver 가 파일 변경 시 프로세스를 재시작하므로 문제없음. 운영은 gunicorn 재기동 시 자연스럽게 리셋. |
+| view 분기 코드가 Phase 3 에서 정리될 때 잊혀짐 | Phase 3 issue 본문에 "feature flag 제거" 를 명시. |
+| QueryResult dataclass 를 state dict 에 담는 것이 LangGraph 정책상 비권장인가 우려 | state serialization/checkpointing 을 쓰지 않으므로 비권장 사항 아님. 향후 checkpointer 도입 시 dict 로 전환. |
+
+---
+
+## Out of Scope (Phase 3+)
+
+- `answer_question()` 분해 (Phase 3)
+- view/graph 간 책임 재정리 — history, 예외, 응답 후처리 경계 (Phase 3)
+- feature flag 제거 (Phase 3 마지막)
+- router 실제 분기 로직 (Phase 4)
+- workflow / agent 노드 실체 (Phase 5~7)
+- LangSmith / 자체 트레이싱


### PR DESCRIPTION
## Summary
2.0.0 Phase 2. Move the chat request entry point from a direct call to `answer_question()` into a minimal LangGraph (`router → single_shot`). The goal is to land the execution framework so Phase 4+ can add routing/workflow/agent nodes on top of a stable skeleton. No change to service logic, prompts, search, or the JSON response shape — the browser sees the exact same chat.

## Changes
### New `chat/graph/` package
- `state.py` — `GraphState(TypedDict, total=False)` with `question` / `history` / `route` / `result` / `error`. `QueryResult` is stored directly in state (no checkpointer serialization yet).
- `nodes/router.py` — placeholder that returns `{'route': 'single_shot'}`. Docstring flags it as the Phase 4 expansion point.
- `nodes/single_shot.py` — wraps `chat.services.query_pipeline.answer_question`. Catches only `QueryPipelineError` into `state.error`; other exceptions bubble to Django's 500 handler.
- `app.py` — `_compiled_graph()` (lru-cached) builds `StateGraph(GraphState)` with `START → router → (conditional on state.route) → single_shot → END`. Conditional edge keyed on `state['route']` so Phase 4 adds keys/nodes without reshaping the graph. Public entry is `run_chat_graph(question, history)` which returns `QueryResult` or raises `QueryPipelineError`.

### Dependency
- `requirements.txt` adds `langgraph>=0.2` (resolves to 1.1.9 in this build).

### Feature flag
- `AI_Chat/settings.py` — `USE_LANGGRAPH_PIPELINE` via `_env_bool`, default `True`.
- `env.example.txt` / `env.prod.example.txt` gain a commented override so operators can flip to `False` and restart to get the legacy direct-call path back instantly. Flag removal is planned for Phase 3.

### View wiring
- `chat/views/message.py` — branch on the flag:
  - `True` → `run_chat_graph(user_text, history=history)`
  - `False` → `answer_question(user_text, history=history)` (legacy path preserved)
- Both paths return `QueryResult` and raise `QueryPipelineError`, so the surrounding code (history save, JSON response) is untouched.

### Docs
- `resources/plans/2.0.0_Phase 2_LangGraph_적용_개발_설계.md` and `resources/plans/detail/2.0.0_Phase 2_..._플랜.md` checked in.
- `resources/documents/2026-04-23-phase2-langgraph.md` dev log.
- `README.md` sections 10-3 / 11 updated.

## Commits (9, intentionally granular)
```
04072b3 docs: Save Phase 2 design and detailed plan
fa859f7 chore: Add langgraph dependency and chat/graph/ package skeleton
b4add4e feat: Define LangGraph state schema for chat pipeline
9865e01 feat: Add placeholder router node always selecting single_shot
d446ce1 feat: Add single_shot node wrapping answer_question
69cff68 feat: Compile chat graph with router → single_shot edges
1a0200c feat: Add USE_LANGGRAPH_PIPELINE flag with documented override
89597c3 feat: Route chat requests through LangGraph when flag is on
9cc1e9d docs: Document LangGraph entry point and Phase 2 flag
```

## Verification
### Automated (dev container)
- `python manage.py check` — OK.
- `from langgraph.graph import StateGraph, START, END` — OK, installed 1.1.9.
- `_compiled_graph().nodes.keys()` → `['__start__', 'router', 'single_shot']`.
- `run_chat_graph('그냥 안녕?', [])` → `QueryResult` with the existing no-sources guard reply.
- `POST /message/` via Django test client → 200 with `{reply, sources, chat_log_id}` keys, identical to pre-Phase 2 shape.

### Manual (browser, confirmed by user)
- Sourced question: same tone / source badges / feedback buttons as before.
- Unsourced question: “회사 자료에 해당 정보가 없습니다”, no sources or feedback.
- Multi-turn: follow-up like “연차도 그래?” inherits context from the earlier turn.
- `[초기화]` clears the session and the follow-up loses context as expected.

## Out of scope (Phase 3+)
- Feature flag removal and legacy `answer_question()` call site cleanup.
- Decomposing `answer_question()` into graph-native nodes (search / rerank / prompt / LLM / save).
- Real routing logic (Phase 4), workflow/agent nodes (Phase 5–7).
- LangChain / LangSmith / graph checkpointer.

Closes #19