### PR TITLE
fix: Paginate Q&A management lists (10 per page) (#33)

### DIFF
--- a/bo/templates/bo/qa_canonical.html
+++ b/bo/templates/bo/qa_canonical.html
@@ -52,7 +52,7 @@
   {% endfor %}
 {% endif %}
 
-{% if items %}
+{% if page_obj.paginator.count %}
   {% for qa in items %}
     <article class="qa-card" data-qa-id="{{ qa.pk }}">
       <h2 class="qa-question">Q. {{ qa.question }}</h2>
@@ -95,6 +95,33 @@
       </form>
     </article>
   {% endfor %}
+
+  {% if page_obj.paginator.num_pages > 1 %}
+    <nav class="pagination">
+      <div class="pagination-row">
+        {% if page_obj.has_previous %}
+          <a class="pagination-btn" href="?page={{ page_obj.previous_page_number }}">‹ 이전</a>
+        {% else %}
+          <span class="pagination-btn disabled">‹ 이전</span>
+        {% endif %}
+
+        {% for n in page_obj.paginator.page_range %}
+          {% if n == page_obj.number %}
+            <span class="pagination-page active">{{ n }}</span>
+          {% else %}
+            <a class="pagination-page" href="?page={{ n }}">{{ n }}</a>
+          {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+          <a class="pagination-btn" href="?page={{ page_obj.next_page_number }}">다음 ›</a>
+        {% else %}
+          <span class="pagination-btn disabled">다음 ›</span>
+        {% endif %}
+      </div>
+      <div class="pagination-info">총 {{ total_count }}건</div>
+    </nav>
+  {% endif %}
 {% else %}
   <div class="empty-state">
     <div class="empty-state-title">공식 Q&amp;A가 없습니다</div>

--- a/bo/templates/bo/qa_feedback.html
+++ b/bo/templates/bo/qa_feedback.html
@@ -34,7 +34,7 @@
   </a>
 </nav>
 
-{% if items %}
+{% if page_obj.paginator.count %}
   {% for cl in items %}
     <article class="qa-card">
       <h2 class="qa-question">Q. {{ cl.question }}</h2>
@@ -67,6 +67,33 @@
       </div>
     </article>
   {% endfor %}
+
+  {% if page_obj.paginator.num_pages > 1 %}
+    <nav class="pagination">
+      <div class="pagination-row">
+        {% if page_obj.has_previous %}
+          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
+        {% else %}
+          <span class="pagination-btn disabled">‹ 이전</span>
+        {% endif %}
+
+        {% for n in page_obj.paginator.page_range %}
+          {% if n == page_obj.number %}
+            <span class="pagination-page active">{{ n }}</span>
+          {% else %}
+            <a class="pagination-page" href="?tab={{ tab }}&page={{ n }}">{{ n }}</a>
+          {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.next_page_number }}">다음 ›</a>
+        {% else %}
+          <span class="pagination-btn disabled">다음 ›</span>
+        {% endif %}
+      </div>
+      <div class="pagination-info">총 {{ total_count }}건</div>
+    </nav>
+  {% endif %}
 {% else %}
   <div class="empty-state">
     <div class="empty-state-title">

--- a/bo/templates/bo/qa_logs.html
+++ b/bo/templates/bo/qa_logs.html
@@ -34,7 +34,7 @@
   </a>
 </nav>
 
-{% if items %}
+{% if page_obj.paginator.count %}
   {% for cl in items %}
     <article class="qa-card">
       <h2 class="qa-question">Q. {{ cl.question }}</h2>
@@ -67,6 +67,33 @@
       </div>
     </article>
   {% endfor %}
+
+  {% if page_obj.paginator.num_pages > 1 %}
+    <nav class="pagination">
+      <div class="pagination-row">
+        {% if page_obj.has_previous %}
+          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
+        {% else %}
+          <span class="pagination-btn disabled">‹ 이전</span>
+        {% endif %}
+
+        {% for n in page_obj.paginator.page_range %}
+          {% if n == page_obj.number %}
+            <span class="pagination-page active">{{ n }}</span>
+          {% else %}
+            <a class="pagination-page" href="?tab={{ tab }}&page={{ n }}">{{ n }}</a>
+          {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.next_page_number }}">다음 ›</a>
+        {% else %}
+          <span class="pagination-btn disabled">다음 ›</span>
+        {% endif %}
+      </div>
+      <div class="pagination-info">총 {{ total_count }}건</div>
+    </nav>
+  {% endif %}
 {% else %}
   <div class="empty-state">
     <div class="empty-state-title">

--- a/bo/views/qa.py
+++ b/bo/views/qa.py
@@ -9,6 +9,7 @@
 from urllib.parse import urlparse
 
 from django.contrib import messages
+from django.core.paginator import Paginator
 from django.db.models import Count, F, Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
@@ -18,7 +19,10 @@ from chat.services.qa_retriever import promote_to_canonical
 from files.models import Document
 
 
-PAGE_SIZE = 50
+# 페이지당 항목 수. 대화 로그·피드백·공식 Q&A 세 섹션 공통.
+# files 관리(20) 보다 작은 이유: Q&A 카드 한 장의 높이(질문+답변+메타+액션)가
+# 파일 행보다 훨씬 커서 한 화면에 너무 많이 깔리면 스크롤 피로가 큼.
+PAGE_SIZE = 10
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +54,9 @@ def qa_logs(request):
         tab = 'all'
         qs = base_qs
 
-    items = list(qs.order_by('-created_at')[:PAGE_SIZE])
+    paginator = Paginator(qs.order_by('-created_at'), PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get('page'))
+    items = list(page_obj.object_list)
     _enrich_with_sources(items)
 
     # 탭별 카운트
@@ -64,6 +70,8 @@ def qa_logs(request):
     context = {
         'section': 'logs',
         'items': items,
+        'page_obj': page_obj,
+        'total_count': paginator.count,
         'tab': tab,
         'tab_counts': tab_counts,
         'counts': {
@@ -100,7 +108,9 @@ def qa_feedback(request):
         tab = 'all'
         qs = base_qs.annotate(total=Count('feedbacks')).filter(total__gt=0).order_by('-total', '-created_at')
 
-    items = list(qs[:PAGE_SIZE])
+    paginator = Paginator(qs, PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get('page'))
+    items = list(page_obj.object_list)
     _enrich_with_sources(items)
 
     # 카운트 — 동일 로직으로 집계
@@ -119,7 +129,14 @@ def qa_feedback(request):
         'canonical': CanonicalQA.objects.count(),
     }
 
-    context = {'section': 'feedback', 'items': items, 'tab': tab, 'counts': counts}
+    context = {
+        'section': 'feedback',
+        'items': items,
+        'page_obj': page_obj,
+        'total_count': paginator.count,
+        'tab': tab,
+        'counts': counts,
+    }
     return render(request, 'bo/qa_feedback.html', context)
 
 
@@ -128,7 +145,10 @@ def qa_feedback(request):
 # ---------------------------------------------------------------------------
 
 def qa_canonical(request):
-    items = list(CanonicalQA.objects.select_related('source_chatlog').order_by('-created_at')[:PAGE_SIZE])
+    base_qs = CanonicalQA.objects.select_related('source_chatlog').order_by('-created_at')
+    paginator = Paginator(base_qs, PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get('page'))
+    items = list(page_obj.object_list)
 
     referenced_ids = {did for qa in items for did in (qa.sources or [])}
     doc_names = {
@@ -144,6 +164,8 @@ def qa_canonical(request):
     context = {
         'section': 'canonical',
         'items': items,
+        'page_obj': page_obj,
+        'total_count': paginator.count,
         'counts': {
             'logs': ChatLog.objects.count(),
             'feedback': Feedback.objects.values('chat_log_id').distinct().count(),


### PR DESCRIPTION
## Summary

The three Q&A management sections (대화 로그 / 답변 응답 / 공식 Q&A) silently capped their querysets at `[:PAGE_SIZE]` (50) without any pagination UI, so every record past the fiftieth was invisible in BO. Replace the cap with Django's `Paginator` at 10 items per page and reuse the existing `.pagination` component already used by `/bo/files/`.

- `bo/views/qa.py`: switch `qa_logs`, `qa_feedback`, `qa_canonical` to `Paginator(..., PAGE_SIZE)` where `PAGE_SIZE = 10`. Each view passes `page_obj` and `total_count` so the templates can render the shared pagination nav.
- `qa_logs.html` and `qa_feedback.html`: append the same pagination block `files.html` uses, but every href preserves the active tab (`?tab={{ tab }}&page=...`) so paging doesn't drop the filter.
- `qa_canonical.html`: identical pagination block without the tab preservation (no tabs on that page).
- Empty-state guard switched from `{% if items %}` to `{% if page_obj.paginator.count %}` so the condition stays accurate no matter which page the user lands on.

## Why 10 per page?

Q&A cards are much taller than file rows (question + answer + meta + actions), so filing them at 20 per page (the files-page default) would turn each tab into a long scroll. Ten per page keeps one screen readable and pagination obviously clickable.

## Test plan

- [ ] `docker compose exec -T web python manage.py check` passes
- [ ] `docker compose exec -T web python manage.py test chat.tests` green (114/114)
- [ ] Shell smoke hits `/bo/qa/logs/`, `/bo/qa/logs/?tab=pending`, `/bo/qa/logs/?tab=all&page=2`, `/bo/qa/feedback/`, `/bo/qa/canonical/` — all 200
- [ ] Browser: with more than 10 chat logs, pagination nav appears on `/bo/qa/logs/`
- [ ] Navigating to page 2 preserves the current tab (`?tab=...&page=2`)
- [ ] Switching tabs while on page 2 resets to page 1 (intentional — each tab starts fresh)
- [ ] `/bo/qa/canonical/` uses plain `?page=N`

Closes #33