### PR TITLE
feat: Add bulk select/actions and question search to Q&A pages (#35)

### DIFF
--- a/bo/static/bo/bo.css
+++ b/bo/static/bo/bo.css
@@ -231,6 +231,61 @@ a { color: inherit; text-decoration: none; }
   font-size: var(--font-size-xs);
 }
 
+/* 가이드 §Button/Secondary — 중립 버튼(검색 폼의 "초기화" 같은 보조 액션용) */
+.btn-secondary {
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong, var(--color-border));
+}
+.btn-secondary:hover:not(:disabled) {
+  background: var(--color-bg-secondary);
+}
+
+/* 가이드 §Search Input — refresh (필터 초기화) 버튼의 아이콘 회전 연출 */
+@keyframes refreshSpin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(-360deg); }
+}
+.refresh-icon { display: block; }
+.refresh-btn:hover .refresh-icon {
+  animation: refreshSpin 0.5s ease forwards;
+}
+
+/* ============================================================
+   INPUT WITH ICON (DesignGuideline §Search Input / Input with Icon)
+   ============================================================ */
+.input-icon-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.input-icon {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.input-icon-left  { left: var(--space-3); }
+.input-icon-right { right: 0; }
+.input-with-icon-left {
+  padding-left: calc(var(--space-3) + 14px + var(--space-2));
+}
+.input-with-icon-right {
+  padding-right: calc(var(--space-3) + 20px + var(--space-2));
+}
+.input-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  right: var(--space-2);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-base);
+}
+.input-icon-btn:hover { background: var(--color-bg-secondary); }
+
 /* ============================================================
    TABLE
    ============================================================ */

--- a/bo/static/bo/bo.css
+++ b/bo/static/bo/bo.css
@@ -269,10 +269,13 @@ a { color: inherit; text-decoration: none; }
 }
 .input-icon-left  { left: var(--space-3); }
 .input-icon-right { right: 0; }
-.input-with-icon-left {
+/* `.input` 가 padding shorthand 로 좌/우 패딩을 덮어쓰기 때문에, 같은 specificity
+   로는 패딩이 먹히지 않는다. `.input.input-with-icon-*` 로 특이도를 한 단계 올려
+   shorthand 를 확실히 이긴다. */
+.input.input-with-icon-left {
   padding-left: calc(var(--space-3) + 14px + var(--space-2));
 }
-.input-with-icon-right {
+.input.input-with-icon-right {
   padding-right: calc(var(--space-3) + 20px + var(--space-2));
 }
 .input-icon-btn {

--- a/bo/templates/bo/_qa_bulk_script.html
+++ b/bo/templates/bo/_qa_bulk_script.html
@@ -1,0 +1,105 @@
+{% comment %}Q&A 페이지 공용 — 수정 모드 토글 / 카드 클릭 선택 / 전체 선택 / bulk 액션 JS.
+
+세 페이지(qa_logs, qa_feedback, qa_canonical) 모두 같은 마크업 규약을 따르기 때문에
+동일 스크립트 하나를 include 한다.
+
+마크업 규약:
+- 페이지 헤더 버튼: .qa-edit-toggle[data-qa-edit-toggle]
+- 컨텐츠 래퍼   : .qa-page (여기에 .bulk-mode 클래스를 on/off)
+- 툴바         : .qa-bulk-toolbar (CSS 가 .qa-page.bulk-mode 일 때만 display:flex)
+- 카드         : .qa-card[data-qa-id="N"], 내부에 <input type="checkbox" class="qa-bulk-check" hidden>
+- 툴바 버튼    : data-qa-select-all / data-qa-bulk-promote / data-qa-bulk-delete
+- 카운터       : data-qa-selected-count
+{% endcomment %}
+<script>
+  (function () {
+    const page = document.querySelector('.qa-page');
+    const toggleBtn = document.querySelector('[data-qa-edit-toggle]');
+    const toolbar = document.querySelector('[data-qa-bulk-toolbar]');
+    if (!page || !toggleBtn || !toolbar) return;
+
+    const selectAllBtn = toolbar.querySelector('[data-qa-select-all]');
+    const actionBtns = toolbar.querySelectorAll('button[type="submit"]');
+    const countEl = toolbar.querySelector('[data-qa-selected-count]');
+
+    function checkboxes() {
+      return Array.from(page.querySelectorAll('.qa-bulk-check'));
+    }
+
+    function refreshState() {
+      const boxes = checkboxes();
+      const selected = boxes.filter((b) => b.checked);
+      countEl.textContent = String(selected.length);
+      actionBtns.forEach((b) => {
+        b.disabled = selected.length === 0;
+      });
+      if (selectAllBtn) {
+        selectAllBtn.textContent = (boxes.length > 0 && selected.length === boxes.length)
+          ? '전체 해제'
+          : '전체 선택';
+      }
+    }
+
+    function setSelected(card, on) {
+      const box = card.querySelector('.qa-bulk-check');
+      if (!box) return;
+      box.checked = on;
+      card.classList.toggle('selected', on);
+    }
+
+    function clearAll() {
+      page.querySelectorAll('.qa-card').forEach((c) => setSelected(c, false));
+      refreshState();
+    }
+
+    // 수정 / 완료 토글
+    toggleBtn.addEventListener('click', () => {
+      const on = !page.classList.contains('bulk-mode');
+      page.classList.toggle('bulk-mode', on);
+      toggleBtn.classList.toggle('active', on);
+      toggleBtn.textContent = on ? '완료' : '수정';
+      if (!on) clearAll();     // 완료로 돌아갈 때는 선택 비움
+      else refreshState();     // 진입 시 버튼 상태 동기화
+    });
+
+    // 카드 클릭 → 선택 토글 (.bulk-mode 에서만, 내부 인터랙티브 요소는 제외)
+    page.addEventListener('click', (e) => {
+      if (!page.classList.contains('bulk-mode')) return;
+      const card = e.target.closest('.qa-card');
+      if (!card) return;
+      // 카드 내부의 링크/버튼/폼은 기존 동작 유지 — 선택 토글 막음
+      if (e.target.closest('a, button, form, input, textarea, select, label')) return;
+      const box = card.querySelector('.qa-bulk-check');
+      if (!box) return;
+      setSelected(card, !box.checked);
+      refreshState();
+    });
+
+    // 전체 선택 / 전체 해제
+    if (selectAllBtn) {
+      selectAllBtn.addEventListener('click', () => {
+        const boxes = checkboxes();
+        const allSelected = boxes.length > 0 && boxes.every((b) => b.checked);
+        boxes.forEach((b) => {
+          const card = b.closest('.qa-card');
+          setSelected(card, !allSelected);
+        });
+        refreshState();
+      });
+    }
+
+    // 삭제 계열 버튼에 확인창 (data-qa-confirm 값을 메시지로 사용)
+    actionBtns.forEach((btn) => {
+      const msg = btn.getAttribute('data-qa-confirm');
+      if (!msg) return;
+      btn.addEventListener('click', (e) => {
+        if (!confirm(msg)) {
+          e.preventDefault();
+        }
+      });
+    });
+
+    // 초기 상태
+    refreshState();
+  })();
+</script>

--- a/bo/templates/bo/_qa_styles.html
+++ b/bo/templates/bo/_qa_styles.html
@@ -144,25 +144,19 @@
   .qa-edit-actions { margin-top: var(--space-2); }
 
   /* ── 검색 폼 (탭 바로 아래) ───────────────────────────────────── */
+  /* 내부 구성요소는 가이드라인 .input-icon-wrap / .input.input-with-icon-left
+     / .btn.btn-primary / .btn.btn-secondary.refresh-btn 을 그대로 사용한다. */
   .qa-search {
     display: flex;
     gap: var(--space-2);
     margin-bottom: var(--space-4);
+    max-width: 520px;
   }
-  .qa-search input[type="search"] {
-    flex: 1;
-    max-width: 360px;
-    padding: var(--space-2) var(--space-3);
-    font-size: var(--font-size-sm);
-    color: var(--color-text-primary);
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    outline: none;
-  }
-  .qa-search input[type="search"]:focus {
-    border-color: var(--color-accent-border);
-    box-shadow: 0 0 0 3px var(--color-accent-light);
+  .qa-search .input-icon-wrap { flex: 1; }
+  .qa-search .refresh-btn {
+    flex-shrink: 0;
+    width: 38px;
+    padding: 0;
   }
 
   /* ── 일괄 선택 모드 ─────────────────────────────────────────── */

--- a/bo/templates/bo/_qa_styles.html
+++ b/bo/templates/bo/_qa_styles.html
@@ -142,4 +142,73 @@
     justify-content: flex-end;
   }
   .qa-edit-actions { margin-top: var(--space-2); }
+
+  /* ── 검색 폼 (탭 바로 아래) ───────────────────────────────────── */
+  .qa-search {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+  }
+  .qa-search input[type="search"] {
+    flex: 1;
+    max-width: 360px;
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    outline: none;
+  }
+  .qa-search input[type="search"]:focus {
+    border-color: var(--color-accent-border);
+    box-shadow: 0 0 0 3px var(--color-accent-light);
+  }
+
+  /* ── 일괄 선택 모드 ─────────────────────────────────────────── */
+  /* 툴바와 선택 스타일은 기본적으로 숨겨져 있다가 .bulk-mode 가 켜지면 드러난다. */
+  .qa-bulk-toolbar {
+    display: none;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-4);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+  }
+  .qa-bulk-toolbar .qa-bulk-count {
+    margin-left: auto;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+  }
+  .qa-page.bulk-mode .qa-bulk-toolbar { display: flex; }
+
+  /* 편집 모드에서 카드 자체가 클릭 타깃처럼 보이게 */
+  .qa-page.bulk-mode .qa-card {
+    cursor: pointer;
+    transition: border-color var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+  }
+  .qa-page.bulk-mode .qa-card:hover {
+    border-color: var(--color-accent-border);
+  }
+  .qa-page.bulk-mode .qa-card.selected {
+    border: 2px solid var(--color-accent);
+    background: var(--color-accent-light);
+    /* 2px 테두리 증가분을 패딩으로 보정해 내부 레이아웃 흔들림 방지 */
+    padding: calc(var(--space-5) - 1px);
+  }
+
+  /* 편집 모드에서 단건 액션·편집 폼은 숨긴다. bulk 액션 사용을 유도. */
+  .qa-page.bulk-mode .qa-actions,
+  .qa-page.bulk-mode .qa-answer-editor-form {
+    display: none !important;
+  }
+
+  /* 편집 모드 토글 버튼이 활성 상태일 때 식별되도록 */
+  .qa-edit-toggle.active {
+    background: var(--color-accent-light);
+    border-color: var(--color-accent);
+    color: var(--color-accent-text);
+  }
 </style>

--- a/bo/templates/bo/_qa_styles.html
+++ b/bo/templates/bo/_qa_styles.html
@@ -145,14 +145,14 @@
 
   /* ── 검색 폼 (탭 바로 아래) ───────────────────────────────────── */
   /* 내부 구성요소는 가이드라인 .input-icon-wrap / .input.input-with-icon-left
-     / .btn.btn-primary / .btn.btn-secondary.refresh-btn 을 그대로 사용한다. */
+     / .btn.btn-primary / .btn.btn-secondary.refresh-btn 을 그대로 사용한다.
+     폭은 아래 카드 리스트와 같이 가로 전체를 쓴다. */
   .qa-search {
     display: flex;
     gap: var(--space-2);
     margin-bottom: var(--space-4);
-    max-width: 520px;
   }
-  .qa-search .input-icon-wrap { flex: 1; }
+  .qa-search .input-icon-wrap { flex: 1; min-width: 0; }
   .qa-search .refresh-btn {
     flex-shrink: 0;
     width: 38px;

--- a/bo/templates/bo/qa_canonical.html
+++ b/bo/templates/bo/qa_canonical.html
@@ -42,6 +42,7 @@
     <h1 class="page-title">Q&amp;A 관리</h1>
     <p class="page-description">챗봇이 검색·재사용하는 공식 Q&amp;A 목록입니다. 편집·삭제할 수 있습니다.</p>
   </div>
+  <button type="button" class="btn qa-edit-toggle" data-qa-edit-toggle>수정</button>
 </header>
 
 {% include 'bo/_qa_subnav.html' %}
@@ -52,85 +53,113 @@
   {% endfor %}
 {% endif %}
 
-{% if page_obj.paginator.count %}
-  {% for qa in items %}
-    <article class="qa-card" data-qa-id="{{ qa.pk }}">
-      <h2 class="qa-question">Q. {{ qa.question }}</h2>
-      <div class="qa-meta">
-        <span>생성: {{ qa.created_at|date:"Y-m-d H:i" }}</span>
-        {% if qa.source_chatlog %}
-          <span>ChatLog #{{ qa.source_chatlog_id }} 에서 승격</span>
-        {% endif %}
-        {% if qa.source_names %}
-          <span>출처: {{ qa.source_names|join:", " }}</span>
-        {% endif %}
-      </div>
+<div class="qa-page">
+  <form class="qa-search" method="get" role="search">
+    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
+    <button type="submit" class="btn">검색</button>
+    {% if q %}<a class="btn" href="?">초기화</a>{% endif %}
+  </form>
 
-      <div class="qa-answer-display">
-        <div class="qa-answer">A. {{ qa.answer }}</div>
-        <div class="qa-actions">
-          <button type="button" class="btn btn-sm" data-edit-btn>편집</button>
-          <form method="post" action="{% url 'bo:qa_canonical_delete' qa.pk %}" style="display: inline;"
-                onsubmit="return confirm('이 공식 Q&amp;A를 삭제하시겠습니까?');">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-danger">삭제</button>
-          </form>
-        </div>
-      </div>
+  <form id="qa-bulk-form" method="post">{% csrf_token %}</form>
 
-      <form method="post" action="{% url 'bo:qa_canonical_update' qa.pk %}" class="qa-answer-editor-form canonical-editor" style="display: none;">
-        {% csrf_token %}
-        <div>
-          <label>질문</label>
-          <input type="text" name="question" value="{{ qa.question }}" required>
-        </div>
-        <div>
-          <label>답변</label>
-          <textarea name="answer" required>{{ qa.answer }}</textarea>
-        </div>
-        <div class="qa-edit-actions">
-          <button type="button" class="btn btn-sm" data-cancel-edit-btn>취소</button>
-          <button type="submit" class="btn btn-sm btn-primary">저장</button>
-        </div>
-      </form>
-    </article>
-  {% endfor %}
-
-  {% if page_obj.paginator.num_pages > 1 %}
-    <nav class="pagination">
-      <div class="pagination-row">
-        {% if page_obj.has_previous %}
-          <a class="pagination-btn" href="?page={{ page_obj.previous_page_number }}">‹ 이전</a>
-        {% else %}
-          <span class="pagination-btn disabled">‹ 이전</span>
-        {% endif %}
-
-        {% for n in page_obj.paginator.page_range %}
-          {% if n == page_obj.number %}
-            <span class="pagination-page active">{{ n }}</span>
-          {% else %}
-            <a class="pagination-page" href="?page={{ n }}">{{ n }}</a>
-          {% endif %}
-        {% endfor %}
-
-        {% if page_obj.has_next %}
-          <a class="pagination-btn" href="?page={{ page_obj.next_page_number }}">다음 ›</a>
-        {% else %}
-          <span class="pagination-btn disabled">다음 ›</span>
-        {% endif %}
-      </div>
-      <div class="pagination-info">총 {{ total_count }}건</div>
-    </nav>
-  {% endif %}
-{% else %}
-  <div class="empty-state">
-    <div class="empty-state-title">공식 Q&amp;A가 없습니다</div>
-    <div>대화 로그에서 좋은 답변을 [공식 승격]으로 추가하세요.</div>
+  <div class="qa-bulk-toolbar" data-qa-bulk-toolbar>
+    <button type="button" class="btn btn-sm" data-qa-select-all>전체 선택</button>
+    <button type="submit" class="btn btn-sm btn-danger" form="qa-bulk-form"
+            formaction="{% url 'bo:qa_bulk_delete_canonical' %}"
+            data-qa-bulk-delete
+            data-qa-confirm="선택한 공식 Q&A 를 모두 삭제하시겠습니까?"
+            disabled>선택 삭제</button>
+    <span class="qa-bulk-count"><span data-qa-selected-count>0</span>개 선택됨</span>
   </div>
-{% endif %}
+
+  {% if page_obj.paginator.count %}
+    {% for qa in items %}
+      <article class="qa-card" data-qa-id="{{ qa.pk }}">
+        <input type="checkbox" name="ids" value="{{ qa.pk }}" form="qa-bulk-form"
+               class="qa-bulk-check" hidden>
+        <h2 class="qa-question">Q. {{ qa.question }}</h2>
+        <div class="qa-meta">
+          <span>생성: {{ qa.created_at|date:"Y-m-d H:i" }}</span>
+          {% if qa.source_chatlog %}
+            <span>ChatLog #{{ qa.source_chatlog_id }} 에서 승격</span>
+          {% endif %}
+          {% if qa.source_names %}
+            <span>출처: {{ qa.source_names|join:", " }}</span>
+          {% endif %}
+        </div>
+
+        <div class="qa-answer-display">
+          <div class="qa-answer">A. {{ qa.answer }}</div>
+          <div class="qa-actions">
+            <button type="button" class="btn btn-sm" data-edit-btn>편집</button>
+            <form method="post" action="{% url 'bo:qa_canonical_delete' qa.pk %}" style="display: inline;"
+                  onsubmit="return confirm('이 공식 Q&amp;A를 삭제하시겠습니까?');">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-danger">삭제</button>
+            </form>
+          </div>
+        </div>
+
+        <form method="post" action="{% url 'bo:qa_canonical_update' qa.pk %}" class="qa-answer-editor-form canonical-editor" style="display: none;">
+          {% csrf_token %}
+          <div>
+            <label>질문</label>
+            <input type="text" name="question" value="{{ qa.question }}" required>
+          </div>
+          <div>
+            <label>답변</label>
+            <textarea name="answer" required>{{ qa.answer }}</textarea>
+          </div>
+          <div class="qa-edit-actions">
+            <button type="button" class="btn btn-sm" data-cancel-edit-btn>취소</button>
+            <button type="submit" class="btn btn-sm btn-primary">저장</button>
+          </div>
+        </form>
+      </article>
+    {% endfor %}
+
+    {% if page_obj.paginator.num_pages > 1 %}
+      <nav class="pagination">
+        <div class="pagination-row">
+          {% if page_obj.has_previous %}
+            <a class="pagination-btn" href="?{% if q %}q={{ q }}&{% endif %}page={{ page_obj.previous_page_number }}">‹ 이전</a>
+          {% else %}
+            <span class="pagination-btn disabled">‹ 이전</span>
+          {% endif %}
+
+          {% for n in page_obj.paginator.page_range %}
+            {% if n == page_obj.number %}
+              <span class="pagination-page active">{{ n }}</span>
+            {% else %}
+              <a class="pagination-page" href="?{% if q %}q={{ q }}&{% endif %}page={{ n }}">{{ n }}</a>
+            {% endif %}
+          {% endfor %}
+
+          {% if page_obj.has_next %}
+            <a class="pagination-btn" href="?{% if q %}q={{ q }}&{% endif %}page={{ page_obj.next_page_number }}">다음 ›</a>
+          {% else %}
+            <span class="pagination-btn disabled">다음 ›</span>
+          {% endif %}
+        </div>
+        <div class="pagination-info">총 {{ total_count }}건</div>
+      </nav>
+    {% endif %}
+  {% else %}
+    <div class="empty-state">
+      <div class="empty-state-title">
+        {% if q %}"{{ q }}" 에 대한 결과가 없습니다{% else %}공식 Q&amp;A가 없습니다{% endif %}
+      </div>
+      <div>
+        {% if q %}검색어를 바꾸거나 초기화 해보세요.
+        {% else %}대화 로그에서 좋은 답변을 [공식 승격]으로 추가하세요.{% endif %}
+      </div>
+    </div>
+  {% endif %}
+</div>
 {% endblock %}
 
 {% block scripts %}
+{% include 'bo/_qa_bulk_script.html' %}
 <script>
   (function () {
     document.querySelectorAll('.qa-card').forEach((card) => {

--- a/bo/templates/bo/qa_canonical.html
+++ b/bo/templates/bo/qa_canonical.html
@@ -55,9 +55,25 @@
 
 <div class="qa-page">
   <form class="qa-search" method="get" role="search">
-    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
-    <button type="submit" class="btn">검색</button>
-    {% if q %}<a class="btn" href="?">초기화</a>{% endif %}
+    <div class="input-icon-wrap">
+      <span class="input-icon input-icon-left">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </span>
+      <input class="input input-with-icon-left" type="search" name="q" value="{{ q }}"
+             placeholder="질문 검색…" aria-label="질문 검색">
+    </div>
+    {% if q %}
+      <a class="btn btn-secondary refresh-btn" href="?" title="검색 초기화" aria-label="검색 초기화">
+        <svg class="refresh-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M4 12a8 8 0 1 0 1.5-4.7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          <path d="M4 5v4h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
+    {% endif %}
+    <button type="submit" class="btn btn-primary">검색</button>
   </form>
 
   <form id="qa-bulk-form" method="post">{% csrf_token %}</form>

--- a/bo/templates/bo/qa_feedback.html
+++ b/bo/templates/bo/qa_feedback.html
@@ -38,9 +38,25 @@
 
   <form class="qa-search" method="get" role="search">
     <input type="hidden" name="tab" value="{{ tab }}">
-    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
-    <button type="submit" class="btn">검색</button>
-    {% if q %}<a class="btn" href="?tab={{ tab }}">초기화</a>{% endif %}
+    <div class="input-icon-wrap">
+      <span class="input-icon input-icon-left">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </span>
+      <input class="input input-with-icon-left" type="search" name="q" value="{{ q }}"
+             placeholder="질문 검색…" aria-label="질문 검색">
+    </div>
+    {% if q %}
+      <a class="btn btn-secondary refresh-btn" href="?tab={{ tab }}" title="검색 초기화" aria-label="검색 초기화">
+        <svg class="refresh-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M4 12a8 8 0 1 0 1.5-4.7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          <path d="M4 5v4h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
+    {% endif %}
+    <button type="submit" class="btn btn-primary">검색</button>
   </form>
 
   <form id="qa-bulk-form" method="post">{% csrf_token %}</form>

--- a/bo/templates/bo/qa_feedback.html
+++ b/bo/templates/bo/qa_feedback.html
@@ -12,6 +12,7 @@
     <h1 class="page-title">Q&amp;A 관리</h1>
     <p class="page-description">사용자가 엄지 피드백을 남긴 대화입니다. 나쁨이 많은 순으로 먼저 확인하세요.</p>
   </div>
+  <button type="button" class="btn qa-edit-toggle" data-qa-edit-toggle>수정</button>
 </header>
 
 {% include 'bo/_qa_subnav.html' %}
@@ -22,84 +23,121 @@
   {% endfor %}
 {% endif %}
 
-<nav class="qa-tabs">
-  <a class="qa-tab {% if tab == 'all' %}active{% endif %}" href="?tab=all">
-    전체 <span class="qa-tab-count">{{ counts.all }}</span>
-  </a>
-  <a class="qa-tab {% if tab == 'up' %}active{% endif %}" href="?tab=up">
-    좋음 <span class="qa-tab-count">{{ counts.up }}</span>
-  </a>
-  <a class="qa-tab {% if tab == 'down' %}active{% endif %}" href="?tab=down">
-    나쁨 <span class="qa-tab-count">{{ counts.down }}</span>
-  </a>
-</nav>
+<div class="qa-page">
+  <nav class="qa-tabs">
+    <a class="qa-tab {% if tab == 'all' %}active{% endif %}" href="?tab=all{% if q %}&q={{ q }}{% endif %}">
+      전체 <span class="qa-tab-count">{{ counts.all }}</span>
+    </a>
+    <a class="qa-tab {% if tab == 'up' %}active{% endif %}" href="?tab=up{% if q %}&q={{ q }}{% endif %}">
+      좋음 <span class="qa-tab-count">{{ counts.up }}</span>
+    </a>
+    <a class="qa-tab {% if tab == 'down' %}active{% endif %}" href="?tab=down{% if q %}&q={{ q }}{% endif %}">
+      나쁨 <span class="qa-tab-count">{{ counts.down }}</span>
+    </a>
+  </nav>
 
-{% if page_obj.paginator.count %}
-  {% for cl in items %}
-    <article class="qa-card">
-      <h2 class="qa-question">Q. {{ cl.question }}</h2>
-      <div class="qa-meta">
-        {% if cl.promoted_count > 0 %}
-          <span class="badge badge-success">공식 Q&amp;A 승격됨</span>
-        {% endif %}
-        <span>생성: {{ cl.created_at|date:"Y-m-d H:i" }}</span>
-        <span class="qa-feedback-count">👍 {{ cl.up_count }}</span>
-        <span class="qa-feedback-count">👎 {{ cl.down_count }}</span>
-        {% if cl.source_names %}
-          <span>출처: {{ cl.source_names|join:", " }}</span>
-        {% endif %}
-      </div>
-      <div class="qa-answer">A. {{ cl.answer }}</div>
-      <div class="qa-actions">
-        {% if cl.promoted_count > 0 %}
-          <a href="{% url 'bo:qa_canonical' %}" class="btn btn-sm">공식 Q&amp;A 보기</a>
-        {% else %}
-          <form method="post" action="{% url 'bo:qa_promote' cl.pk %}" style="display: inline;">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-primary">공식 승격</button>
-          </form>
-          <form method="post" action="{% url 'bo:qa_log_delete' cl.pk %}" style="display: inline;"
-                onsubmit="return confirm('이 대화 로그를 삭제하시겠습니까?');">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-danger">삭제</button>
-          </form>
-        {% endif %}
-      </div>
-    </article>
-  {% endfor %}
+  <form class="qa-search" method="get" role="search">
+    <input type="hidden" name="tab" value="{{ tab }}">
+    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
+    <button type="submit" class="btn">검색</button>
+    {% if q %}<a class="btn" href="?tab={{ tab }}">초기화</a>{% endif %}
+  </form>
 
-  {% if page_obj.paginator.num_pages > 1 %}
-    <nav class="pagination">
-      <div class="pagination-row">
-        {% if page_obj.has_previous %}
-          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
-        {% else %}
-          <span class="pagination-btn disabled">‹ 이전</span>
-        {% endif %}
+  <form id="qa-bulk-form" method="post">{% csrf_token %}</form>
 
-        {% for n in page_obj.paginator.page_range %}
-          {% if n == page_obj.number %}
-            <span class="pagination-page active">{{ n }}</span>
-          {% else %}
-            <a class="pagination-page" href="?tab={{ tab }}&page={{ n }}">{{ n }}</a>
-          {% endif %}
-        {% endfor %}
-
-        {% if page_obj.has_next %}
-          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.next_page_number }}">다음 ›</a>
-        {% else %}
-          <span class="pagination-btn disabled">다음 ›</span>
-        {% endif %}
-      </div>
-      <div class="pagination-info">총 {{ total_count }}건</div>
-    </nav>
-  {% endif %}
-{% else %}
-  <div class="empty-state">
-    <div class="empty-state-title">
-      {% if tab == 'down' %}👎 받은 대화가 없습니다{% elif tab == 'up' %}👍 받은 대화가 없습니다{% else %}피드백 있는 대화가 없습니다{% endif %}
-    </div>
-    <div>채팅에서 엄지 피드백이 달리면 여기에 모입니다.</div>
+  <div class="qa-bulk-toolbar" data-qa-bulk-toolbar>
+    <button type="button" class="btn btn-sm" data-qa-select-all>전체 선택</button>
+    <button type="submit" class="btn btn-sm btn-primary" form="qa-bulk-form"
+            formaction="{% url 'bo:qa_bulk_promote' %}"
+            data-qa-bulk-promote
+            disabled>선택 승격</button>
+    <button type="submit" class="btn btn-sm btn-danger" form="qa-bulk-form"
+            formaction="{% url 'bo:qa_bulk_delete_logs' %}"
+            data-qa-bulk-delete
+            data-qa-confirm="선택한 대화 로그를 모두 삭제하시겠습니까?"
+            disabled>선택 삭제</button>
+    <span class="qa-bulk-count"><span data-qa-selected-count>0</span>개 선택됨</span>
   </div>
-{% endif %}
+
+  {% if page_obj.paginator.count %}
+    {% for cl in items %}
+      <article class="qa-card" data-qa-id="{{ cl.pk }}">
+        <input type="checkbox" name="ids" value="{{ cl.pk }}" form="qa-bulk-form"
+               class="qa-bulk-check" hidden>
+        <h2 class="qa-question">Q. {{ cl.question }}</h2>
+        <div class="qa-meta">
+          {% if cl.promoted_count > 0 %}
+            <span class="badge badge-success">공식 Q&amp;A 승격됨</span>
+          {% endif %}
+          <span>생성: {{ cl.created_at|date:"Y-m-d H:i" }}</span>
+          <span class="qa-feedback-count">👍 {{ cl.up_count }}</span>
+          <span class="qa-feedback-count">👎 {{ cl.down_count }}</span>
+          {% if cl.source_names %}
+            <span>출처: {{ cl.source_names|join:", " }}</span>
+          {% endif %}
+        </div>
+        <div class="qa-answer">A. {{ cl.answer }}</div>
+        <div class="qa-actions">
+          {% if cl.promoted_count > 0 %}
+            <a href="{% url 'bo:qa_canonical' %}" class="btn btn-sm">공식 Q&amp;A 보기</a>
+          {% else %}
+            <form method="post" action="{% url 'bo:qa_promote' cl.pk %}" style="display: inline;">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-primary">공식 승격</button>
+            </form>
+            <form method="post" action="{% url 'bo:qa_log_delete' cl.pk %}" style="display: inline;"
+                  onsubmit="return confirm('이 대화 로그를 삭제하시겠습니까?');">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-danger">삭제</button>
+            </form>
+          {% endif %}
+        </div>
+      </article>
+    {% endfor %}
+
+    {% if page_obj.paginator.num_pages > 1 %}
+      <nav class="pagination">
+        <div class="pagination-row">
+          {% if page_obj.has_previous %}
+            <a class="pagination-btn" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
+          {% else %}
+            <span class="pagination-btn disabled">‹ 이전</span>
+          {% endif %}
+
+          {% for n in page_obj.paginator.page_range %}
+            {% if n == page_obj.number %}
+              <span class="pagination-page active">{{ n }}</span>
+            {% else %}
+              <a class="pagination-page" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ n }}">{{ n }}</a>
+            {% endif %}
+          {% endfor %}
+
+          {% if page_obj.has_next %}
+            <a class="pagination-btn" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ page_obj.next_page_number }}">다음 ›</a>
+          {% else %}
+            <span class="pagination-btn disabled">다음 ›</span>
+          {% endif %}
+        </div>
+        <div class="pagination-info">총 {{ total_count }}건</div>
+      </nav>
+    {% endif %}
+  {% else %}
+    <div class="empty-state">
+      <div class="empty-state-title">
+        {% if q %}"{{ q }}" 에 대한 결과가 없습니다
+        {% elif tab == 'down' %}👎 받은 대화가 없습니다
+        {% elif tab == 'up' %}👍 받은 대화가 없습니다
+        {% else %}피드백 있는 대화가 없습니다{% endif %}
+      </div>
+      <div>
+        {% if q %}검색어를 바꾸거나 초기화 해보세요.
+        {% else %}채팅에서 엄지 피드백이 달리면 여기에 모입니다.{% endif %}
+      </div>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% include 'bo/_qa_bulk_script.html' %}
 {% endblock %}

--- a/bo/templates/bo/qa_logs.html
+++ b/bo/templates/bo/qa_logs.html
@@ -38,9 +38,25 @@
 
   <form class="qa-search" method="get" role="search">
     <input type="hidden" name="tab" value="{{ tab }}">
-    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
-    <button type="submit" class="btn">검색</button>
-    {% if q %}<a class="btn" href="?tab={{ tab }}">초기화</a>{% endif %}
+    <div class="input-icon-wrap">
+      <span class="input-icon input-icon-left">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </span>
+      <input class="input input-with-icon-left" type="search" name="q" value="{{ q }}"
+             placeholder="질문 검색…" aria-label="질문 검색">
+    </div>
+    {% if q %}
+      <a class="btn btn-secondary refresh-btn" href="?tab={{ tab }}" title="검색 초기화" aria-label="검색 초기화">
+        <svg class="refresh-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M4 12a8 8 0 1 0 1.5-4.7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          <path d="M4 5v4h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
+    {% endif %}
+    <button type="submit" class="btn btn-primary">검색</button>
   </form>
 
   <form id="qa-bulk-form" method="post">{% csrf_token %}</form>

--- a/bo/templates/bo/qa_logs.html
+++ b/bo/templates/bo/qa_logs.html
@@ -12,6 +12,7 @@
     <h1 class="page-title">Q&amp;A 관리</h1>
     <p class="page-description">모든 채팅 로그입니다. 좋은 답변은 [공식 승격]으로 검색용 공식 Q&amp;A에 추가됩니다.</p>
   </div>
+  <button type="button" class="btn qa-edit-toggle" data-qa-edit-toggle>수정</button>
 </header>
 
 {% include 'bo/_qa_subnav.html' %}
@@ -22,84 +23,121 @@
   {% endfor %}
 {% endif %}
 
-<nav class="qa-tabs">
-  <a class="qa-tab {% if tab == 'all' %}active{% endif %}" href="?tab=all">
-    전체 <span class="qa-tab-count">{{ tab_counts.all }}</span>
-  </a>
-  <a class="qa-tab {% if tab == 'pending' %}active{% endif %}" href="?tab=pending">
-    미승격 <span class="qa-tab-count">{{ tab_counts.pending }}</span>
-  </a>
-  <a class="qa-tab {% if tab == 'promoted' %}active{% endif %}" href="?tab=promoted">
-    승격 <span class="qa-tab-count">{{ tab_counts.promoted }}</span>
-  </a>
-</nav>
+<div class="qa-page">
+  <nav class="qa-tabs">
+    <a class="qa-tab {% if tab == 'all' %}active{% endif %}" href="?tab=all{% if q %}&q={{ q }}{% endif %}">
+      전체 <span class="qa-tab-count">{{ tab_counts.all }}</span>
+    </a>
+    <a class="qa-tab {% if tab == 'pending' %}active{% endif %}" href="?tab=pending{% if q %}&q={{ q }}{% endif %}">
+      미승격 <span class="qa-tab-count">{{ tab_counts.pending }}</span>
+    </a>
+    <a class="qa-tab {% if tab == 'promoted' %}active{% endif %}" href="?tab=promoted{% if q %}&q={{ q }}{% endif %}">
+      승격 <span class="qa-tab-count">{{ tab_counts.promoted }}</span>
+    </a>
+  </nav>
 
-{% if page_obj.paginator.count %}
-  {% for cl in items %}
-    <article class="qa-card">
-      <h2 class="qa-question">Q. {{ cl.question }}</h2>
-      <div class="qa-meta">
-        {% if cl.promoted_count > 0 %}
-          <span class="badge badge-success">공식 Q&amp;A 승격됨</span>
-        {% endif %}
-        <span>생성: {{ cl.created_at|date:"Y-m-d H:i" }}</span>
-        <span class="qa-feedback-count">👍 {{ cl.up_count|default:0 }}</span>
-        <span class="qa-feedback-count">👎 {{ cl.down_count|default:0 }}</span>
-        {% if cl.source_names %}
-          <span>출처: {{ cl.source_names|join:", " }}</span>
-        {% endif %}
-      </div>
-      <div class="qa-answer">A. {{ cl.answer }}</div>
-      <div class="qa-actions">
-        {% if cl.promoted_count > 0 %}
-          <a href="{% url 'bo:qa_canonical' %}" class="btn btn-sm">공식 Q&amp;A 보기</a>
-        {% else %}
-          <form method="post" action="{% url 'bo:qa_promote' cl.pk %}" style="display: inline;">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-primary">공식 승격</button>
-          </form>
-          <form method="post" action="{% url 'bo:qa_log_delete' cl.pk %}" style="display: inline;"
-                onsubmit="return confirm('이 대화 로그를 삭제하시겠습니까?');">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-danger">삭제</button>
-          </form>
-        {% endif %}
-      </div>
-    </article>
-  {% endfor %}
+  <form class="qa-search" method="get" role="search">
+    <input type="hidden" name="tab" value="{{ tab }}">
+    <input type="search" name="q" value="{{ q }}" placeholder="질문 검색…" aria-label="질문 검색">
+    <button type="submit" class="btn">검색</button>
+    {% if q %}<a class="btn" href="?tab={{ tab }}">초기화</a>{% endif %}
+  </form>
 
-  {% if page_obj.paginator.num_pages > 1 %}
-    <nav class="pagination">
-      <div class="pagination-row">
-        {% if page_obj.has_previous %}
-          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
-        {% else %}
-          <span class="pagination-btn disabled">‹ 이전</span>
-        {% endif %}
+  <form id="qa-bulk-form" method="post">{% csrf_token %}</form>
 
-        {% for n in page_obj.paginator.page_range %}
-          {% if n == page_obj.number %}
-            <span class="pagination-page active">{{ n }}</span>
-          {% else %}
-            <a class="pagination-page" href="?tab={{ tab }}&page={{ n }}">{{ n }}</a>
-          {% endif %}
-        {% endfor %}
-
-        {% if page_obj.has_next %}
-          <a class="pagination-btn" href="?tab={{ tab }}&page={{ page_obj.next_page_number }}">다음 ›</a>
-        {% else %}
-          <span class="pagination-btn disabled">다음 ›</span>
-        {% endif %}
-      </div>
-      <div class="pagination-info">총 {{ total_count }}건</div>
-    </nav>
-  {% endif %}
-{% else %}
-  <div class="empty-state">
-    <div class="empty-state-title">
-      {% if tab == 'pending' %}미승격 대화 로그가 없습니다{% elif tab == 'promoted' %}승격된 대화 로그가 없습니다{% else %}아직 대화 로그가 없습니다{% endif %}
-    </div>
-    <div>채팅에서 회사 자료 기반 답변이 나오면 여기에 쌓입니다.</div>
+  <div class="qa-bulk-toolbar" data-qa-bulk-toolbar>
+    <button type="button" class="btn btn-sm" data-qa-select-all>전체 선택</button>
+    <button type="submit" class="btn btn-sm btn-primary" form="qa-bulk-form"
+            formaction="{% url 'bo:qa_bulk_promote' %}"
+            data-qa-bulk-promote
+            disabled>선택 승격</button>
+    <button type="submit" class="btn btn-sm btn-danger" form="qa-bulk-form"
+            formaction="{% url 'bo:qa_bulk_delete_logs' %}"
+            data-qa-bulk-delete
+            data-qa-confirm="선택한 대화 로그를 모두 삭제하시겠습니까?"
+            disabled>선택 삭제</button>
+    <span class="qa-bulk-count"><span data-qa-selected-count>0</span>개 선택됨</span>
   </div>
-{% endif %}
+
+  {% if page_obj.paginator.count %}
+    {% for cl in items %}
+      <article class="qa-card" data-qa-id="{{ cl.pk }}">
+        <input type="checkbox" name="ids" value="{{ cl.pk }}" form="qa-bulk-form"
+               class="qa-bulk-check" hidden>
+        <h2 class="qa-question">Q. {{ cl.question }}</h2>
+        <div class="qa-meta">
+          {% if cl.promoted_count > 0 %}
+            <span class="badge badge-success">공식 Q&amp;A 승격됨</span>
+          {% endif %}
+          <span>생성: {{ cl.created_at|date:"Y-m-d H:i" }}</span>
+          <span class="qa-feedback-count">👍 {{ cl.up_count|default:0 }}</span>
+          <span class="qa-feedback-count">👎 {{ cl.down_count|default:0 }}</span>
+          {% if cl.source_names %}
+            <span>출처: {{ cl.source_names|join:", " }}</span>
+          {% endif %}
+        </div>
+        <div class="qa-answer">A. {{ cl.answer }}</div>
+        <div class="qa-actions">
+          {% if cl.promoted_count > 0 %}
+            <a href="{% url 'bo:qa_canonical' %}" class="btn btn-sm">공식 Q&amp;A 보기</a>
+          {% else %}
+            <form method="post" action="{% url 'bo:qa_promote' cl.pk %}" style="display: inline;">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-primary">공식 승격</button>
+            </form>
+            <form method="post" action="{% url 'bo:qa_log_delete' cl.pk %}" style="display: inline;"
+                  onsubmit="return confirm('이 대화 로그를 삭제하시겠습니까?');">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-danger">삭제</button>
+            </form>
+          {% endif %}
+        </div>
+      </article>
+    {% endfor %}
+
+    {% if page_obj.paginator.num_pages > 1 %}
+      <nav class="pagination">
+        <div class="pagination-row">
+          {% if page_obj.has_previous %}
+            <a class="pagination-btn" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ page_obj.previous_page_number }}">‹ 이전</a>
+          {% else %}
+            <span class="pagination-btn disabled">‹ 이전</span>
+          {% endif %}
+
+          {% for n in page_obj.paginator.page_range %}
+            {% if n == page_obj.number %}
+              <span class="pagination-page active">{{ n }}</span>
+            {% else %}
+              <a class="pagination-page" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ n }}">{{ n }}</a>
+            {% endif %}
+          {% endfor %}
+
+          {% if page_obj.has_next %}
+            <a class="pagination-btn" href="?tab={{ tab }}{% if q %}&q={{ q }}{% endif %}&page={{ page_obj.next_page_number }}">다음 ›</a>
+          {% else %}
+            <span class="pagination-btn disabled">다음 ›</span>
+          {% endif %}
+        </div>
+        <div class="pagination-info">총 {{ total_count }}건</div>
+      </nav>
+    {% endif %}
+  {% else %}
+    <div class="empty-state">
+      <div class="empty-state-title">
+        {% if q %}"{{ q }}" 에 대한 결과가 없습니다
+        {% elif tab == 'pending' %}미승격 대화 로그가 없습니다
+        {% elif tab == 'promoted' %}승격된 대화 로그가 없습니다
+        {% else %}아직 대화 로그가 없습니다{% endif %}
+      </div>
+      <div>
+        {% if q %}검색어를 바꾸거나 초기화 해보세요.
+        {% else %}채팅에서 회사 자료 기반 답변이 나오면 여기에 쌓입니다.{% endif %}
+      </div>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% include 'bo/_qa_bulk_script.html' %}
 {% endblock %}

--- a/bo/urls.py
+++ b/bo/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
     path('qa/canonical/<int:pk>/update/', views.qa_canonical_update, name='qa_canonical_update'),
     path('qa/canonical/<int:pk>/delete/', views.qa_canonical_delete, name='qa_canonical_delete'),
 
+    # 일괄 액션 (bulk) — ids[] POST 로 받음
+    path('qa/logs/bulk-promote/', views.qa_bulk_promote, name='qa_bulk_promote'),
+    path('qa/logs/bulk-delete/', views.qa_bulk_delete_logs, name='qa_bulk_delete_logs'),
+    path('qa/canonical/bulk-delete/', views.qa_bulk_delete_canonical, name='qa_bulk_delete_canonical'),
+
     # Prompt 관리 (registry 기반 allow-list 편집기)
     path('prompts/', views.prompts_index, name='prompts'),
     path('prompts/<slug:key>/', views.prompts_edit, name='prompts_edit'),

--- a/bo/views/__init__.py
+++ b/bo/views/__init__.py
@@ -11,6 +11,9 @@ from .qa import (
     qa_log_delete,
     qa_canonical_update,
     qa_canonical_delete,
+    qa_bulk_promote,
+    qa_bulk_delete_logs,
+    qa_bulk_delete_canonical,
 )
 from .router_rules import (
     router_rules_index,

--- a/bo/views/qa.py
+++ b/bo/views/qa.py
@@ -39,6 +39,7 @@ def qa_root(request):
 
 def qa_logs(request):
     tab = request.GET.get('tab', 'all')
+    q = (request.GET.get('q') or '').strip()
 
     base_qs = ChatLog.objects.annotate(
         up_count=Count('feedbacks', filter=Q(feedbacks__rating=Feedback.Rating.UP)),
@@ -54,12 +55,15 @@ def qa_logs(request):
         tab = 'all'
         qs = base_qs
 
+    if q:
+        qs = qs.filter(question__icontains=q)
+
     paginator = Paginator(qs.order_by('-created_at'), PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get('page'))
     items = list(page_obj.object_list)
     _enrich_with_sources(items)
 
-    # 탭별 카운트
+    # 탭별 카운트 — 검색어는 적용하지 않는다(탭 배지는 전체 규모를 보여줘야 함)
     all_base = ChatLog.objects.annotate(promoted_count=Count('promotions'))
     tab_counts = {
         'pending': all_base.filter(promoted_count=0).count(),
@@ -73,6 +77,7 @@ def qa_logs(request):
         'page_obj': page_obj,
         'total_count': paginator.count,
         'tab': tab,
+        'q': q,
         'tab_counts': tab_counts,
         'counts': {
             'logs': ChatLog.objects.count(),
@@ -89,6 +94,7 @@ def qa_logs(request):
 
 def qa_feedback(request):
     tab = request.GET.get('tab', 'all')
+    q = (request.GET.get('q') or '').strip()
 
     base_qs = (
         ChatLog.objects
@@ -108,12 +114,15 @@ def qa_feedback(request):
         tab = 'all'
         qs = base_qs.annotate(total=Count('feedbacks')).filter(total__gt=0).order_by('-total', '-created_at')
 
+    if q:
+        qs = qs.filter(question__icontains=q)
+
     paginator = Paginator(qs, PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get('page'))
     items = list(page_obj.object_list)
     _enrich_with_sources(items)
 
-    # 카운트 — 동일 로직으로 집계
+    # 카운트 — 동일 로직으로 집계 (검색어 적용 없음)
     feedback_base = ChatLog.objects.annotate(
         up=Count('feedbacks', filter=Q(feedbacks__rating=Feedback.Rating.UP)),
         down=Count('feedbacks', filter=Q(feedbacks__rating=Feedback.Rating.DOWN)),
@@ -135,6 +144,7 @@ def qa_feedback(request):
         'page_obj': page_obj,
         'total_count': paginator.count,
         'tab': tab,
+        'q': q,
         'counts': counts,
     }
     return render(request, 'bo/qa_feedback.html', context)
@@ -145,7 +155,12 @@ def qa_feedback(request):
 # ---------------------------------------------------------------------------
 
 def qa_canonical(request):
+    q = (request.GET.get('q') or '').strip()
+
     base_qs = CanonicalQA.objects.select_related('source_chatlog').order_by('-created_at')
+    if q:
+        base_qs = base_qs.filter(question__icontains=q)
+
     paginator = Paginator(base_qs, PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get('page'))
     items = list(page_obj.object_list)
@@ -166,6 +181,7 @@ def qa_canonical(request):
         'items': items,
         'page_obj': page_obj,
         'total_count': paginator.count,
+        'q': q,
         'counts': {
             'logs': ChatLog.objects.count(),
             'feedback': Feedback.objects.values('chat_log_id').distinct().count(),
@@ -235,6 +251,87 @@ def qa_canonical_delete(request, pk):
 
 
 # ---------------------------------------------------------------------------
+# 일괄 액션 (Bulk)
+# ---------------------------------------------------------------------------
+
+@require_POST
+def qa_bulk_promote(request):
+    """선택된 ChatLog 들을 한 번에 공식 Q&A 로 승격.
+
+    이미 승격된 로그는 자동 제외(단건 `qa_promote` 와 동일한 규칙을 유지).
+    """
+    ids = _parsed_ids(request)
+    if not ids:
+        messages.error(request, '선택된 항목이 없습니다.')
+        return redirect(_back_to(request))
+
+    targets = (
+        ChatLog.objects
+        .annotate(promoted_count=Count('promotions'))
+        .filter(pk__in=ids, promoted_count=0)
+    )
+    promoted = 0
+    for cl in targets:
+        promote_to_canonical(cl)
+        promoted += 1
+
+    skipped = len(ids) - promoted
+    if promoted and skipped:
+        messages.success(request, f'{promoted}건 승격, {skipped}건은 이미 승격돼 건너뜀.')
+    elif promoted:
+        messages.success(request, f'{promoted}건을 공식 Q&A 로 승격했습니다.')
+    else:
+        messages.error(request, '이미 모두 승격된 로그입니다.')
+    return redirect(_back_to(request))
+
+
+@require_POST
+def qa_bulk_delete_logs(request):
+    """선택된 ChatLog 일괄 삭제.
+
+    승격된 로그는 단건 규칙대로 이 경로에서 삭제 불가(공식 Q&A 창에서만).
+    """
+    ids = _parsed_ids(request)
+    if not ids:
+        messages.error(request, '선택된 항목이 없습니다.')
+        return redirect(_back_to(request))
+
+    # 삭제 제외 대상(이미 승격된 로그) pk 집합을 먼저 추린다.
+    promoted_ids = set(
+        ChatLog.objects
+        .annotate(promoted_count=Count('promotions'))
+        .filter(pk__in=ids, promoted_count__gt=0)
+        .values_list('pk', flat=True)
+    )
+    deletable_ids = [i for i in ids if i not in promoted_ids]
+    ChatLog.objects.filter(pk__in=deletable_ids).delete()
+
+    deleted = len(deletable_ids)
+    skipped = len(promoted_ids)
+    if deleted and skipped:
+        messages.success(request, f'{deleted}건 삭제, {skipped}건은 승격됨 상태라 건너뜀.')
+    elif deleted:
+        messages.success(request, f'{deleted}건을 삭제했습니다.')
+    else:
+        messages.error(request, '선택한 로그 모두 승격됨 상태라 삭제할 수 없습니다.')
+    return redirect(_back_to(request))
+
+
+@require_POST
+def qa_bulk_delete_canonical(request):
+    """선택된 공식 Q&A 일괄 삭제."""
+    ids = _parsed_ids(request)
+    if not ids:
+        messages.error(request, '선택된 항목이 없습니다.')
+        return redirect(_back_to(request))
+
+    deleted = CanonicalQA.objects.filter(pk__in=ids).count()
+    CanonicalQA.objects.filter(pk__in=ids).delete()
+    messages.success(request, f'{deleted}건을 삭제했습니다.')
+    return redirect(_back_to(request))
+
+
+# ---------------------------------------------------------------------------
 # 헬퍼
 # ---------------------------------------------------------------------------
 
@@ -258,3 +355,21 @@ def _back_to(request) -> str:
         if p.path.startswith('/bo/qa/'):
             return ref
     return '/bo/qa/logs/'
+
+
+def _parsed_ids(request) -> list[int]:
+    """POST body 의 `ids` 목록을 정수 리스트로. 숫자 아닌 값은 버린다."""
+    result: list[int] = []
+    for raw in request.POST.getlist('ids'):
+        try:
+            result.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    # 중복 제거 + 순서 보존
+    seen: set[int] = set()
+    unique: list[int] = []
+    for i in result:
+        if i not in seen:
+            seen.add(i)
+            unique.append(i)
+    return unique


### PR DESCRIPTION
## Summary

Two related improvements to the three Q&A management pages (대화 로그 / 답변 응답 / 공식 Q&A):

### 1. Edit mode + bulk actions

Each page header gets a **수정** button that flips the list into edit mode (client-side only — page reloads reset). In edit mode:

- Clicking a card toggles selection; selected cards get an accent-blue border (`border: 2px var(--color-accent)` + accent-light tint). No visible checkbox — the card itself is the target.
- A toolbar above the list shows **전체 선택 / 선택 승격 / 선택 삭제**, keeping the submit buttons `disabled` until at least one card is selected. A running `N개 선택됨` counter sits on the right.
- Per-card 승격 / 삭제 / 편집 controls are hidden while edit mode is on.
- Selection does NOT persist across pagination — explicitly requested.

Backend adds three bulk endpoints under `/bo/qa/.../bulk-.../`:

- `qa_bulk_promote` — promotes selected ChatLogs, skipping ones already promoted (same guard as single `qa_promote`).
- `qa_bulk_delete_logs` — deletes selected ChatLogs, skipping promoted ones (same guard as single `qa_log_delete`).
- `qa_bulk_delete_canonical` — deletes selected CanonicalQAs.

All three parse `ids[]` with a shared `_parsed_ids` helper (int coercion + dedupe + order-preserving) and flash a summary like `3건 삭제, 1건은 승격됨 상태라 건너뜀.`

Markup trick: the bulk `<form>` sits outside the card list and every card's hidden checkbox opts in via the HTML5 `form="qa-bulk-form"` attribute. That keeps the existing per-card inline forms (promote / delete / edit on canonical) from becoming invalidly nested.

Shared JS lives in `bo/templates/bo/_qa_bulk_script.html` and is included by all three list templates.

### 2. Question search

A search row below the tab bar, identical on all three pages:

- `?q=...` applies `question__icontains` against the current queryset. Answers are intentionally not searched to avoid noisy matches.
- URL parameter threading: tab links carry `q`, pagination links carry both `tab` and `q`, the search form carries `tab` as a hidden field. Submitting the form or switching tabs resets `page` to 1.
- Empty-state copy distinguishes "no search results" from "no data yet" and offers an 초기화 link when `q` is active.

### 3. Guideline alignment

The search controls were initially styled ad-hoc; the refactor commit rebuilds them on top of `DesignGuideline` components:

- `.input-icon-wrap` + left magnifier SVG + `.input.input-with-icon-left` instead of a bare `<input type="search">`.
- `검색` button promoted to `.btn.btn-primary`.
- `초기화` replaced with an icon-only square `.btn.btn-secondary.refresh-btn` (circular-arrow SVG, hover-spin animation).

Ported the supporting CSS (`.btn-secondary`, `.refresh-btn`, `@keyframes refreshSpin`, the `.input-icon-*` family) into `bo.css` so other BO pages can reuse the same search pattern.

Two follow-up fixes: `.input.input-with-icon-left` specificity bump so `.input`'s `padding` shorthand stops stomping the icon gap; drop the 520px cap on `.qa-search` so the form stretches to the card width.

## Test plan

- [ ] `docker compose exec -T web python manage.py check` passes
- [ ] `docker compose exec -T web python manage.py test chat.tests` green (114/114)
- [ ] `/bo/qa/logs/`, `/bo/qa/feedback/`, `/bo/qa/canonical/` all respond 200 with tabs / `q` / `page` combinations
- [ ] `수정` button toggles edit mode; `완료` clears selection
- [ ] Click on a card in edit mode → accent-blue border + counter increments; click again → deselect
- [ ] `전체 선택` selects every card on the current page; click again to deselect all (label flips to `전체 해제`)
- [ ] Selected counter updates live; bulk action buttons stay `disabled` at 0 selection
- [ ] Bulk 승격 works and flashes a summary; already-promoted cards are skipped
- [ ] Bulk 삭제 works with a confirm dialog; promoted logs are skipped (logs page), canonical deletes succeed
- [ ] Navigating pages clears the selection (and edit mode as expected after reload)
- [ ] Search: typing in 질문 검색 + submit filters results; 초기화 returns to the full list; switching tab with a search term keeps `q`; pagination carries both `tab` and `q`
- [ ] Empty-state shows the tailored "'...' 에 대한 결과가 없습니다" when `q` has no matches

Closes #35