### PR TITLE
docs: Finalize release docs for v0.4.0 (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,7 @@
 
 버전은 [SemVer](https://semver.org/lang/ko/) 정책. release 는 `release on demand` (사용자 명시 요청 시 develop → main + tag).
 
-## [Unreleased] — 2026-04-29 시점 develop
-
-### Phase 9 — 안정화 및 배포 준비 (in progress)
-
-- **자동 회귀 가드** 신규 — 라우팅 e2e (`test_routing_e2e.py`) + 파이프라인 smoke (`test_pipeline_smoke.py`) + prompt registry 정합 (`PromptRegistryConsistencyTests`).
-- 12 대표 질문셋 + 회귀 체크리스트 + 배포 체크리스트 dev log 정리.
-- Phase 1~8 의 모든 dev log 인용한 본 CHANGELOG 신규.
-
----
-
-## [0.4.0] — 미배포
+## [0.4.0] — 2026-04-29
 
 > 0.3.x → 0.4.0 의 핵심 변화는 "단일 single-shot RAG → LangGraph 기반 3분류 (single_shot / workflow / agent) 운영 가능 구조" 로의 전환.
 
@@ -49,6 +39,12 @@
 
 - **후속 질문 잡음** — `비싼거` 같이 맥락 의존 질문이 무관 PDF 와 매치되던 문제. Phase 4-3 query rewriter 로 해소.
 - **인사말 잡음** — `안녕하세요` 같은 짧은 답변에 출처 / 피드백 / ChatLog 가 잘못 표시되던 문제. `classify_reply` 의 `_CASUAL_MARKERS` 분류로 해소.
+
+### Stabilization (Phase 9)
+
+- **자동 회귀 가드** 신규 — 라우팅 e2e (`test_routing_e2e.py`) + 파이프라인 smoke (`test_pipeline_smoke.py`) + prompt registry 정합 (`PromptRegistryConsistencyTests`). 총 19 cases 추가, 523/523 그린.
+- 12 대표 질문셋 (single_shot 3 / workflow 3 / agent 3 / edge 3) + 회귀 체크리스트 + 배포 체크리스트 dev log 정리.
+- 본 CHANGELOG 신규 (Phase 1~9 모든 dev log 인용).
 
 ### Migration / Deployment
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ pending → processing → reviewing → processing → ready
 | `POSTGRES_DB` | DB 이름 | 로컬 기본 `mydb` |
 | `OPENAI_API_KEY` | OpenAI API 키 | `sk-proj-...` 형식 |
 | `OPENAI_MODEL` | 사용 모델 | 기본 `gpt-4o-mini` |
+| `OPENAI_ADMIN_KEY` | (선택) OpenAI Admin 키 | `sk-admin-...` 형식. BO 대시보드의 `API 사용량` 모달 (외부 청구 조회) 전용. 미설정 시 모달만 503 안내, 채팅 기능엔 영향 없음. 발급: https://platform.openai.com/settings/organization/admin-keys |
 
 **실행 순서**
 1. `docker compose up -d` — web(Django, 8001) + db(PostgreSQL 17, 5432) 컨테이너 기동.

--- a/env.example.txt
+++ b/env.example.txt
@@ -24,6 +24,14 @@ OPENAI_API_KEY=여기에_OpenAI_API_키_입력
 # 사용 모델 (기본: gpt-4o-mini)
 OPENAI_MODEL=gpt-4o-mini
 
+# (선택) OpenAI Admin 키 — `sk-admin-...` 형식.
+# BO 대시보드의 `API 사용량` 모달이 OpenAI Organization 의 외부 청구
+# 데이터를 가져올 때만 필요. 일반 `OPENAI_API_KEY` 로는 접근 불가한
+# /v1/organization/usage/* 엔드포인트 전용.
+# 발급: https://platform.openai.com/settings/organization/admin-keys
+# 미설정 시 BO 모달이 안내 메시지로 503 응답 — 채팅 기능엔 영향 없음.
+# OPENAI_ADMIN_KEY=sk-admin-...
+
 # ── Prompt 관리 ─────────────────────────────────────────
 # 프롬프트 파일 루트. 기본값은 repo 내부 assets/prompts/.
 # 운영에서 재배포 없이 수정하고 싶으면 외부 마운트 경로로 override.


### PR DESCRIPTION
## Summary

Final docs hygiene before cutting `v0.4.0`. Two pre-release fixes bundled:

1. **CHANGELOG** — merge `[Unreleased]` Phase 9 entries into `[0.4.0]`, replace `미배포` with the actual release date `2026-04-29`.
2. **OPENAI_ADMIN_KEY env var** — add to `env.example.txt` and the README §10 environment variables table. The variable was introduced in Phase 4-4 for the BO usage widget but was never documented for setup.

## Changes

### CHANGELOG
- Drop `[Unreleased] — 2026-04-29 시점 develop` heading
- Add `### Stabilization (Phase 9)` subsection inside `[0.4.0]`
- `## [0.4.0] — 미배포` → `## [0.4.0] — 2026-04-29`

### env docs
- `env.example.txt`: commented-out `OPENAI_ADMIN_KEY=sk-admin-...` block with explanation, source link, and behavior on absence
- `README.md` §10 env table: new row marked `(선택)` with the same context

## Test plan

- [x] CHANGELOG renders cleanly
- [x] env.example.txt is still valid shell-style (commented optional)
- [x] No code touched

Closes #67