### PR TITLE
fix: Skip number range check when min/max attribute is absent (#70)

### DIFF
--- a/bo/static/bo/bo.js
+++ b/bo/static/bo/bo.js
@@ -90,8 +90,12 @@
         let firstInvalid = null;
         inputs.forEach((input) => {
           const v = (input.value || '').trim();
-          const min = Number(input.getAttribute('min'));
-          const max = Number(input.getAttribute('max'));
+          // parseFloat 는 null / '' 에 대해 NaN 을 반환 — Number() 와 달리 0 으로
+          // 묵시 변환되지 않아 "속성 없음" 과 "0" 을 명확히 구분한다. 이전 구현은
+          // min/max 속성이 없는 number input (예: RouterRule.priority) 에서 모든
+          // 양수 입력을 0 초과로 판정해 거부하던 회귀의 원인.
+          const min = parseFloat(input.getAttribute('min'));
+          const max = parseFloat(input.getAttribute('max'));
           const num = Number(v);
           let msg = '';
 


### PR DESCRIPTION
## Summary

Hotfix for the v0.4.0 BO router-rule form: priority=100 (default) gets rejected with "0 이하여야 합니다." Same trap applies to any `<input type="number">` rendered without `min`/`max` HTML attributes.

## Root cause

`bo/static/bo/bo.js` used `Number(input.getAttribute('min'/'max'))`. `Number(null)` is `0`, and `Number.isFinite(0)` is `true`, so the implicit range was treated as `[0, 0]` whenever the attribute was missing — and every non-zero value failed.

## Fix

Switch to `parseFloat`. `parseFloat(null)` and `parseFloat('')` return `NaN`, which fails `Number.isFinite`, so the range check is skipped only when the attribute is genuinely absent. Existing fields that set explicit `min`/`max` still validate correctly.

## Verification

- `manage.py test` — 523/523 green
- Browser end-to-end: filled BO `/bo/router-rules/new/` with name + workflow + 며칠 + date_calculation, default priority=100 — submission succeeded, rule persisted with `priority=100, workflow_key=date_calculation`.

## Post-merge

1. Tag `v0.4.1` on main.
2. Push tag → triggers GHCR release pipeline → operations get the fix.
3. Back-merge `main` → `develop`.

Fixes #70