### PR TITLE
fix: Add agent calendar tools and DATE_CONDITION routing tier (#73)

### DIFF
--- a/assets/prompts/chat/agent_react.md
+++ b/assets/prompts/chat/agent_react.md
@@ -36,3 +36,10 @@ Reading retrieval observations:
 - If the snippet contains the values or facts you need (e.g. table rows like "본인 결혼 100만원"), use them directly in `final_answer`. **Do NOT claim "자료를 찾지 못했습니다" when the snippet has the answer.**
 - If the snippet shows only headers/titles and not the values you need, your next step should be **another `retrieve_documents` with a more specific query** (e.g. add "금액", "일수", "표", or specific terms) — not `final_answer` claiming no data. The chunk likely contains the data past the truncation point; a sharper query repositions the relevant region into the snippet.
 - **[관련성 낮음] / 머리 마커 인지** (Phase 7-4): retrieve observation 의 청크 출처 앞에 `[관련성 낮음]` 가 붙으면 그 청크는 query 의 핵심 의미 토큰 (가장 긴 non-trivial token) 미매치 — snippet 의 일부 단어가 우연히 매치돼 윈도우는 만들어졌어도 실질 관련성은 낮음. 청크 1~2개에만 있으면 다른 청크가 관련 있을 수 있으니 그걸 우선 사용. 단 summary 머리에 **`[query 핵심 토큰 매치 없음 — 관련 자료 부족 가능성]`** 가 있으면 corpus 에 자료가 없는 것 — query 를 다듬어 다시 retrieve 하지 말고 `final_answer` 로 정직하게 "자료를 찾지 못했습니다" 종료.
+
+조건절 처리 (v0.4.2):
+
+- 자료 검색 결과에 **"토요일/일요일/공휴일이면 익일에 ..." 같은 조건절** 이 보이고 사용자 질문이 **특정 날짜·월** 의 적용을 묻고 있다면, 직접 요일을 추측하지 말고 **`is_business_day` 또는 `next_business_day` 도구로 실제 적용 결과를 계산** 한 뒤 답변에 반영.
+- 예: 자료에 "임금은 매월 21일 지급. 토/일/공휴일이면 익일." 이 있고 사용자가 `26년 6월 임금 지급일은?` 이라 물으면 → `next_business_day({"date": "2026-06-21"})` → 결과 (`2026-06-22 월요일, 다음 영업일`) 를 답변에 직접 인용.
+- LLM 이 머릿속으로 "2026-06-21 은 X요일" 을 단정하지 말 것 — 미래 날짜의 요일 추측은 종종 틀린다.
+- 조건절이 없거나 사용자가 단순 정보만 묻는다면 도구 호출 불필요 — `final_answer` 로 자료 인용 그대로 종료.

--- a/bo/templates/bo/router_rules.html
+++ b/bo/templates/bo/router_rules.html
@@ -273,6 +273,19 @@
   <div class="defaults-body">
     <div class="card">
       <div class="defaults-card-header">
+        <span class="badge badge-warning">agent (조건절)</span>
+      </div>
+      <div class="defaults-card-keywords">
+        {% for kw in date_condition_keywords %}
+          <span class="kw-tag">{{ kw }}</span>
+        {% endfor %}
+      </div>
+      <div class="defaults-card-note">
+        조건절 적용이 필요한 날짜 질문 — 자료의 "토/공휴일이면 익일" 류를 calendar 도구로 처리하기 위해 agent 로 라우팅. WORKFLOW 보다 먼저 평가 (v0.4.2).
+      </div>
+    </div>
+    <div class="card">
+      <div class="defaults-card-header">
         <span class="badge badge-info">workflow</span>
       </div>
       <div class="defaults-card-keywords">

--- a/bo/tests.py
+++ b/bo/tests.py
@@ -243,6 +243,67 @@ class RouterRulesBulkActionsTests(TestCase):
         self.assertFalse(RouterRule.objects.filter(pk=self.r1.pk).exists())
 
 
+class RouterRuleFormDuplicatePreventionTests(TestCase):
+    """v0.4.2 (이슈 #73 검증 부산물) — 같은 (pattern, match_type) RouterRule 중복 등록 거부."""
+
+    def setUp(self):
+        from chat.models import RouterRule
+        self.existing = RouterRule.objects.create(
+            name='기존 며칠', route='workflow', match_type='contains',
+            pattern='며칠', priority=100, enabled=True,
+            workflow_key='date_calculation',
+        )
+
+    def _form_data(self, **overrides):
+        data = {
+            'name': '신규 며칠',
+            'route': 'workflow',
+            'match_type': 'contains',
+            'pattern': '며칠',
+            'workflow_key': 'date_calculation',
+            'priority': 100,
+            'enabled': 'on',
+            'description': '',
+        }
+        data.update(overrides)
+        return data
+
+    def test_duplicate_pattern_match_type_rejected(self):
+        from bo.views.router_rules import RouterRuleForm
+        form = RouterRuleForm(self._form_data())
+        self.assertFalse(form.is_valid())
+        self.assertIn('이미 있습니다', str(form.errors))
+
+    def test_different_match_type_allowed(self):
+        from bo.views.router_rules import RouterRuleForm
+        # 같은 pattern 이라도 match_type 이 다르면 허용 (현재는 contains 만 사용중이지만
+        # 미래 정확 일치 / 정규식 도입 시를 대비).
+        form = RouterRuleForm(self._form_data(match_type='exact'))
+        self.assertFalse(form.is_valid())  # exact 가 choices 에 없으면 form 자체 invalid
+        # 하지만 pattern/match_type 충돌 에러는 없어야 함.
+        self.assertNotIn('이미 있습니다', str(form.errors))
+
+    def test_different_pattern_allowed(self):
+        from bo.views.router_rules import RouterRuleForm
+        form = RouterRuleForm(self._form_data(pattern='몇 일'))
+        self.assertTrue(form.is_valid(), msg=form.errors)
+
+    def test_whitespace_distinguished(self):
+        from bo.views.router_rules import RouterRuleForm
+        # `며칠` 과 `며 칠` 은 다른 패턴 — 띄어쓰기까지 정확히 일치할 때만 충돌.
+        form = RouterRuleForm(self._form_data(pattern='며 칠'))
+        self.assertTrue(form.is_valid(), msg=form.errors)
+
+    def test_edit_self_does_not_self_conflict(self):
+        from bo.views.router_rules import RouterRuleForm
+        # 기존 rule 편집 시 자기 자신은 제외 — 패턴 그대로 두고 다른 필드만 수정 가능.
+        form = RouterRuleForm(
+            self._form_data(name='이름만 변경'),
+            instance=self.existing,
+        )
+        self.assertTrue(form.is_valid(), msg=form.errors)
+
+
 @override_settings(STORAGES=_NO_MANIFEST_STORAGES)
 class DashboardViewTests(TestCase):
     """Phase 8-5 — `/bo/` 대시보드 GET 회귀 (5 카드 / 비용 컬럼 / purpose 섹션)."""

--- a/bo/views/router_rules.py
+++ b/bo/views/router_rules.py
@@ -84,6 +84,35 @@ class RouterRuleForm(forms.ModelForm):
         # 조회해 choices 를 채운다. 빈 값 포함.
         self.fields['workflow_key'].choices = _workflow_key_choices()
 
+    def clean(self):
+        """같은 (pattern, match_type) 조합의 다른 RouterRule 이 이미 있으면 거부.
+
+        v0.4.2 (이슈 #73 검증 중 발견) — 운영자가 BO 에서 같은 키워드를 실수로
+        두 번 등록할 수 있었음 (`며칠` rule 이 두 개 등록되어 있던 사례). 띄어쓰기
+        포함 정확히 일치하는 패턴 + match_type 조합은 단일 rule 로 충분.
+
+        편집 모드에선 자기 자신은 제외해야 self-conflict 안남 (`pk` 비교).
+        """
+        cleaned = super().clean()
+        pattern = cleaned.get('pattern', '')
+        match_type = cleaned.get('match_type')
+        if not pattern or not match_type:
+            return cleaned
+
+        existing = RouterRule.objects.filter(
+            pattern=pattern, match_type=match_type,
+        )
+        if self.instance.pk is not None:
+            existing = existing.exclude(pk=self.instance.pk)
+        if existing.exists():
+            other = existing.first()
+            raise forms.ValidationError(
+                f'같은 키워드 "{pattern}" + 매칭 방식 "{match_type}" 의 규칙이 '
+                f'이미 있습니다 (이름: "{other.name}"). 기존 규칙을 수정하거나 '
+                f'다른 키워드를 사용하세요.'
+            )
+        return cleaned
+
 
 def router_rules_index(request):
     """RouterRule 목록 + 코드 내장 기본 키워드(읽기 전용).

--- a/bo/views/router_rules.py
+++ b/bo/views/router_rules.py
@@ -16,7 +16,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 
 from chat.models import RouterRule
-from chat.services.question_router import AGENT_KEYWORDS, WORKFLOW_KEYWORDS
+from chat.services.question_router import (
+    AGENT_KEYWORDS,
+    DATE_CONDITION_KEYWORDS,
+    WORKFLOW_KEYWORDS,
+)
 
 
 # 페이지당 RouterRule 수 — 운영자가 한 화면에서 훑기 좋은 양 + 코드 키워드
@@ -98,6 +102,7 @@ def router_rules_index(request):
         'rules': page_obj,                 # 템플릿에서 for 순회 시 현재 페이지 항목
         'page_obj': page_obj,              # 페이지네이션 컨트롤용
         'total_count': paginator.count,
+        'date_condition_keywords': DATE_CONDITION_KEYWORDS,
         'workflow_keywords': WORKFLOW_KEYWORDS,
         'agent_keywords': AGENT_KEYWORDS,
     }

--- a/chat/services/agent/tools_builtin.py
+++ b/chat/services/agent/tools_builtin.py
@@ -1,9 +1,12 @@
-"""Agent 가 처음 쓰는 세 도구 등록 (Phase 7-1).
+"""Agent 도구 등록.
 
   - `retrieve_documents` — Phase 6-3 와 같은 reranker 포함 retrieval. schema 모드.
   - `find_canonical_qa` — 과거 승격된 Q&A 임베딩 검색. schema 모드.
   - `run_workflow` — 등록된 generic workflow 를 그대로 실행. raw 모드 (입력 형태가
     `workflow_key` 마다 달라서 schema 로 강제할 수 없음).
+  - `weekday_of` / `is_business_day` / `next_business_day` (v0.4.2, 이슈 #73) —
+    한국 달력 기준 요일·영업일 판단. 자료 안의 "토/공휴일이면 익일" 류 조건절을
+    실제 날짜에 적용할 때 agent 가 호출.
 
 각 도구는 callable 결과를 LLM 이 다시 보기 좋은 짧은 한국어 한두 줄로 요약한다.
 원본 응답 전체를 다음 iteration 에 올리지 않는다 — 컨텍스트 폭주 방지.
@@ -13,7 +16,10 @@ from __future__ import annotations
 
 import re
 import string
+from datetime import date, datetime, timedelta
 from typing import Any, List, Mapping
+
+import holidays
 
 from chat.services.agent.tools import Tool, register
 from chat.services.single_shot.qa_cache import find_canonical_qa as _qa_cache_find
@@ -358,6 +364,135 @@ def _retrieve_failure_check(result: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Calendar tools (v0.4.2, 이슈 #73)
+# ---------------------------------------------------------------------------
+#
+# 한국 달력 기준 요일·영업일 판단. 자료 안의 "토/공휴일이면 익일" 류 조건절을
+# 실제 날짜에 적용할 때 agent 가 호출한다.
+#
+# 도구 입력은 단일 string `date` 필드로 통일 — agent 가 `arguments={"date":
+# "2026-06-21"}` 형태로 호출. 형식 파싱 실패는 callable 에서 ValueError 를
+# 던져 `tools.call()` 의 `failure_kind='callable_error'` 분기에 흡수 — ReAct
+# loop 가 다른 형식 (`2026.06.21` → `2026-06-21`) 으로 자유롭게 retry.
+
+_KR_HOLIDAYS = holidays.KR(language='ko')  # 한국어 공휴일명. 전역 1회 생성, thread-safe.
+
+_WEEKDAY_KO: tuple[str, ...] = ('월', '화', '수', '목', '금', '토', '일')
+
+# 받아들이는 형식: 2026-06-21 / 2026/06/21 / 2026.06.21 / 20260621.
+# 다른 형식은 ValueError 로 거부 — agent 가 다시 정규화하도록.
+_DATE_FORMATS: tuple[str, ...] = ('%Y-%m-%d', '%Y/%m/%d', '%Y.%m.%d', '%Y%m%d')
+
+
+def _parse_date(raw: Any) -> date:
+    """문자열 또는 date 를 표준 `date` 로 변환. 실패 시 ValueError."""
+    if isinstance(raw, date) and not isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, datetime):
+        return raw.date()
+    if not isinstance(raw, str):
+        raise ValueError(f'date 입력은 문자열이어야 합니다: type={type(raw).__name__}')
+    text = raw.strip()
+    if not text:
+        raise ValueError('date 입력이 비어 있습니다.')
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(
+        f'date 형식을 인식하지 못했습니다: {text!r} '
+        f'(허용: YYYY-MM-DD / YYYY/MM/DD / YYYY.MM.DD / YYYYMMDD)'
+    )
+
+
+def _is_business_day_check(d: date) -> bool:
+    """주말이거나 한국 공휴일이면 False, 그 외 True."""
+    if d.weekday() >= 5:  # 5=토, 6=일
+        return False
+    if d in _KR_HOLIDAYS:
+        return False
+    return True
+
+
+# weekday_of -----------------------------------------------------------------
+
+def _weekday_of_callable(arguments: Mapping[str, Any]) -> dict:
+    d = _parse_date(arguments.get('date'))
+    return {'date': d.isoformat(), 'weekday': _WEEKDAY_KO[d.weekday()]}
+
+
+def _summarize_weekday_of(result: Any) -> str:
+    if not isinstance(result, dict):
+        return f'예상치 못한 응답 형식: {type(result).__name__}'
+    return f"{result.get('date')} = {result.get('weekday')}요일"
+
+
+# is_business_day ------------------------------------------------------------
+
+def _is_business_day_callable(arguments: Mapping[str, Any]) -> dict:
+    d = _parse_date(arguments.get('date'))
+    is_bd = _is_business_day_check(d)
+    holiday_name = _KR_HOLIDAYS.get(d) if d in _KR_HOLIDAYS else None
+    return {
+        'date': d.isoformat(),
+        'weekday': _WEEKDAY_KO[d.weekday()],
+        'is_business_day': is_bd,
+        'holiday_name': holiday_name,
+    }
+
+
+def _summarize_is_business_day(result: Any) -> str:
+    if not isinstance(result, dict):
+        return f'예상치 못한 응답 형식: {type(result).__name__}'
+    iso = result.get('date')
+    weekday = result.get('weekday')
+    if result.get('is_business_day'):
+        return f'{iso} ({weekday}요일) = 영업일'
+    holiday = result.get('holiday_name')
+    if holiday:
+        return f'{iso} ({weekday}요일) = 휴일 — {holiday}'
+    return f'{iso} ({weekday}요일) = 휴일 (주말)'
+
+
+# next_business_day ----------------------------------------------------------
+
+# 무한 루프 방어 — 한국 공휴일이 연속으로 일주일 이상 이어지는 경우는 없음.
+# 30 으로 잡으면 어떤 케이스도 안전.
+_NEXT_BUSINESS_DAY_MAX_STEPS = 30
+
+
+def _next_business_day_callable(arguments: Mapping[str, Any]) -> dict:
+    """입력 날짜가 영업일이면 그대로, 아니면 다음 영업일을 반환."""
+    d = _parse_date(arguments.get('date'))
+    cursor = d
+    for _ in range(_NEXT_BUSINESS_DAY_MAX_STEPS):
+        if _is_business_day_check(cursor):
+            return {
+                'input_date': d.isoformat(),
+                'next_business_day': cursor.isoformat(),
+                'weekday': _WEEKDAY_KO[cursor.weekday()],
+                'shifted': cursor != d,
+            }
+        cursor += timedelta(days=1)
+    # 30일 안에도 못 찾으면 데이터 이상 — 보호적 raise.
+    raise ValueError(
+        f'next_business_day: {d.isoformat()} 부터 {_NEXT_BUSINESS_DAY_MAX_STEPS}일 안에 영업일을 찾지 못함.'
+    )
+
+
+def _summarize_next_business_day(result: Any) -> str:
+    if not isinstance(result, dict):
+        return f'예상치 못한 응답 형식: {type(result).__name__}'
+    in_iso = result.get('input_date')
+    out_iso = result.get('next_business_day')
+    weekday = result.get('weekday')
+    if result.get('shifted'):
+        return f'{in_iso} → {out_iso} ({weekday}요일, 다음 영업일)'
+    return f'{in_iso} = 영업일 그대로 ({weekday}요일)'
+
+
+# ---------------------------------------------------------------------------
 # 등록 — import 부작용
 # ---------------------------------------------------------------------------
 
@@ -401,4 +536,49 @@ register(Tool(
     input_schema=None,   # raw 모드 — workflow_key 마다 input 형태가 달라 schema 강제 X
     callable=_workflow_callable,
     summarize=_summarize_workflow,
+))
+
+
+# v0.4.2 (이슈 #73) — agent 가 자료의 conditional date clause 를 실제 달력에 적용.
+
+register(Tool(
+    name='weekday_of',
+    description=(
+        '주어진 날짜의 요일을 한국어 한 글자로 반환합니다 (월/화/수/목/금/토/일). '
+        'arguments: {"date": "YYYY-MM-DD"} (또는 YYYY/MM/DD, YYYY.MM.DD, YYYYMMDD).'
+    ),
+    input_schema={
+        'date': FieldSpec(type='text', required=True, aliases=('date', '날짜')),
+    },
+    callable=_weekday_of_callable,
+    summarize=_summarize_weekday_of,
+))
+
+
+register(Tool(
+    name='is_business_day',
+    description=(
+        '주어진 날짜가 영업일(주말·한국 공휴일이 아닌 평일)인지 판단합니다. '
+        'arguments: {"date": "YYYY-MM-DD"}. 반환에 holiday_name 이 있으면 공휴일.'
+    ),
+    input_schema={
+        'date': FieldSpec(type='text', required=True, aliases=('date', '날짜')),
+    },
+    callable=_is_business_day_callable,
+    summarize=_summarize_is_business_day,
+))
+
+
+register(Tool(
+    name='next_business_day',
+    description=(
+        '주어진 날짜가 영업일이면 그대로, 주말·공휴일이면 다음 영업일을 반환합니다. '
+        '"토/공휴일이면 익일" 류 규정의 실제 적용일 계산용. '
+        'arguments: {"date": "YYYY-MM-DD"}.'
+    ),
+    input_schema={
+        'date': FieldSpec(type='text', required=True, aliases=('date', '날짜')),
+    },
+    callable=_next_business_day_callable,
+    summarize=_summarize_next_business_day,
 ))

--- a/chat/services/question_router.py
+++ b/chat/services/question_router.py
@@ -1,10 +1,13 @@
-"""질문 분류기 (Phase 4-2 / Phase 6-1 확장).
+"""질문 분류기 (Phase 4-2 / Phase 6-1 / v0.4.2 확장).
 
 graph 의 router_node 가 부른다. 우선순위는:
 
     1. DB RouterRule 조회 (enabled=True, priority DESC) — 매치 있으면 해당 route
-    2. 코드 상수(WORKFLOW_KEYWORDS / AGENT_KEYWORDS) 키워드 매칭
-    3. 그래도 없으면 'single_shot' (default)
+    2. 코드 상수 DATE_CONDITION_KEYWORDS (v0.4.2 — 조건절 적용이 필요한 날짜 질문)
+       → agent (calendar 도구 활용)
+    3. 코드 상수 WORKFLOW_KEYWORDS → workflow
+    4. 코드 상수 AGENT_KEYWORDS → agent
+    5. 그래도 없으면 'single_shot' (default)
 
 코드 상수는 **영구 보존되는 기본 동작**이다. DB rule 은 운영 중 조정하는
 override 계층. BO 에서 rule 을 다 지우거나 DB 가 비어있어도 코드 키워드로
@@ -35,6 +38,15 @@ from typing import List, Optional
 from chat.graph.routes import ROUTE_AGENT, ROUTE_SINGLE_SHOT, ROUTE_WORKFLOW
 
 
+# 조건절 적용이 필요한 날짜 질문 신호 (v0.4.2, 이슈 #73).
+# 자료 안의 "토/공휴일이면 익일" 류 조건절을 실제 달력에 적용하려면 agent 의
+# calendar 도구 (`is_business_day` / `next_business_day`) 가 필요. WORKFLOW_KEYWORDS
+# 보다 **먼저** 평가 — `급여 지급일은?` 같은 합성 질문이 `급여` (WORKFLOW) 에
+# 가로채지지 않도록.
+DATE_CONDITION_KEYWORDS: tuple[str, ...] = (
+    '지급일', '만료일', '정산일', '마감일',
+)
+
 # 정형 계산·산정 성격 질문 신호.
 # BO RouterRule 이 비어있을 때의 fallback 키워드 — '기본 동작' 역할.
 WORKFLOW_KEYWORDS: tuple[str, ...] = (
@@ -56,10 +68,11 @@ class RouteDecision:
     """라우터 결정.
 
     reason 포맷:
-      - 'db_rule:<name>'      — DB RouterRule 매치
-      - 'workflow_keyword'    — 코드 WORKFLOW_KEYWORDS 매치
-      - 'agent_keyword'       — 코드 AGENT_KEYWORDS 매치
-      - 'default'             — 아무것도 매치 안 됨
+      - 'db_rule:<name>'         — DB RouterRule 매치
+      - 'date_condition_keyword' — 코드 DATE_CONDITION_KEYWORDS 매치 (v0.4.2)
+      - 'workflow_keyword'       — 코드 WORKFLOW_KEYWORDS 매치
+      - 'agent_keyword'          — 코드 AGENT_KEYWORDS 매치
+      - 'default'                — 아무것도 매치 안 됨
 
     `workflow_key` (Phase 6-1): `route == 'workflow'` 일 때 어떤 generic
     workflow 로 보낼지. DB RouterRule 이 지정한 값이면 그대로, 코드 키워드
@@ -109,6 +122,16 @@ def route_question(question: str) -> RouteDecision:
     db_decision = _match_db_rules(question)
     if db_decision is not None:
         return db_decision
+
+    # v0.4.2: DATE_CONDITION 을 WORKFLOW 보다 먼저 평가 — 합성 질문 (`급여 지급일`)
+    # 이 WORKFLOW `급여` 에 가로채지지 않게.
+    hits = _matches(question, DATE_CONDITION_KEYWORDS)
+    if hits:
+        return RouteDecision(
+            route=ROUTE_AGENT,
+            reason='date_condition_keyword',
+            matched_rules=hits,
+        )
 
     hits = _matches(question, WORKFLOW_KEYWORDS)
     if hits:

--- a/chat/tests/test_agent_tools_calendar.py
+++ b/chat/tests/test_agent_tools_calendar.py
@@ -1,0 +1,141 @@
+"""v0.4.2 (이슈 #73) — agent calendar 도구 단위 테스트.
+
+- 3 도구 (`weekday_of` / `is_business_day` / `next_business_day`) 의 입력/출력
+- date 형식 변형 (`YYYY-MM-DD` / `YYYY/MM/DD` / `YYYY.MM.DD` / `YYYYMMDD`)
+- 잘못된 입력 → `tools.call()` Observation 의 `failure_kind='callable_error'`
+- 한국 공휴일 정확성 (현충일 / 어린이날 / 광복절 / 삼일절)
+"""
+
+from django.test import SimpleTestCase
+
+from chat.services.agent import tools
+# tools_builtin import 부작용으로 도구가 등록됨.
+from chat.services.agent import tools_builtin  # noqa: F401
+
+
+class WeekdayOfTests(SimpleTestCase):
+    """`weekday_of` — 한국어 한 글자 요일 반환."""
+
+    def test_sunday(self):
+        obs = tools.call('weekday_of', {'date': '2026-06-21'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('일요일', obs.summary)
+
+    def test_monday(self):
+        obs = tools.call('weekday_of', {'date': '2026-06-22'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('월요일', obs.summary)
+
+    def test_alt_format_dot(self):
+        # `YYYY.MM.DD` 도 같은 결과.
+        obs = tools.call('weekday_of', {'date': '2026.06.21'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('일요일', obs.summary)
+
+    def test_alt_format_compact(self):
+        obs = tools.call('weekday_of', {'date': '20260621'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('일요일', obs.summary)
+
+    def test_invalid_date_format(self):
+        obs = tools.call('weekday_of', {'date': 'invalid'})
+        self.assertTrue(obs.is_failure)
+        self.assertEqual(obs.failure_kind, 'callable_error')
+        # ValueError 메시지가 summary 에 포함되는지.
+        self.assertIn('형식', obs.summary)
+
+    def test_empty_date(self):
+        # 빈 문자열은 schema 의 require_fields 단계에서 missing 으로 처리됨 →
+        # callable 호출 전 schema_invalid. callable_error 와 분리.
+        obs = tools.call('weekday_of', {'date': ''})
+        self.assertTrue(obs.is_failure)
+        self.assertEqual(obs.failure_kind, 'schema_invalid')
+
+    def test_missing_required_field(self):
+        # schema 검증으로 `failure_kind='schema_invalid'` (callable 도달 X).
+        obs = tools.call('weekday_of', {})
+        self.assertTrue(obs.is_failure)
+        self.assertEqual(obs.failure_kind, 'schema_invalid')
+
+
+class IsBusinessDayTests(SimpleTestCase):
+    """`is_business_day` — 주말·한국 공휴일 회피."""
+
+    def test_business_day_monday(self):
+        obs = tools.call('is_business_day', {'date': '2026-06-22'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('영업일', obs.summary)
+        self.assertNotIn('휴일', obs.summary)
+
+    def test_weekend_sunday(self):
+        obs = tools.call('is_business_day', {'date': '2026-06-21'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('주말', obs.summary)
+
+    def test_korean_holiday_memorial_day(self):
+        # 현충일 (6월 6일) — `holidays.KR(language='ko')` 로 한국어명.
+        obs = tools.call('is_business_day', {'date': '2026-06-06'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('현충일', obs.summary)
+
+    def test_korean_holiday_independence_day(self):
+        # 삼일절.
+        obs = tools.call('is_business_day', {'date': '2026-03-01'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('삼일절', obs.summary)
+
+    def test_korean_holiday_liberation_day(self):
+        # 광복절.
+        obs = tools.call('is_business_day', {'date': '2026-08-15'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('광복절', obs.summary)
+
+    def test_korean_holiday_childrens_day(self):
+        # 어린이날.
+        obs = tools.call('is_business_day', {'date': '2026-05-05'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('어린이날', obs.summary)
+
+
+class NextBusinessDayTests(SimpleTestCase):
+    """`next_business_day` — 영업일 그대로 / 주말·공휴일이면 다음 영업일."""
+
+    def test_already_business_day(self):
+        obs = tools.call('next_business_day', {'date': '2026-06-22'})
+        self.assertFalse(obs.is_failure)
+        # 같은 날.
+        self.assertIn('영업일 그대로', obs.summary)
+
+    def test_sunday_skips_to_monday(self):
+        # 2026-06-21 (일) → 2026-06-22 (월).
+        obs = tools.call('next_business_day', {'date': '2026-06-21'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('2026-06-22', obs.summary)
+        self.assertIn('월요일', obs.summary)
+
+    def test_saturday_skips_to_monday(self):
+        # 2026-06-20 (토) → 2026-06-22 (월) — 일요일 건너뜀.
+        obs = tools.call('next_business_day', {'date': '2026-06-20'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('2026-06-22', obs.summary)
+
+    def test_holiday_memorial_day_saturday_skips_to_monday(self):
+        # 2026-06-06 (토 + 현충일) → 2026-06-08 (월) — 주말+공휴일 후 월요일.
+        obs = tools.call('next_business_day', {'date': '2026-06-06'})
+        self.assertFalse(obs.is_failure)
+        self.assertIn('2026-06-08', obs.summary)
+
+    def test_invalid_date(self):
+        obs = tools.call('next_business_day', {'date': 'not-a-date'})
+        self.assertTrue(obs.is_failure)
+        self.assertEqual(obs.failure_kind, 'callable_error')
+
+
+class CalendarToolsRegisteredTests(SimpleTestCase):
+    """tools 레지스트리에 3 도구가 등록되어 있는지."""
+
+    def test_registered(self):
+        names = {t.name for t in tools.all_entries()}
+        self.assertIn('weekday_of', names)
+        self.assertIn('is_business_day', names)
+        self.assertIn('next_business_day', names)

--- a/chat/tests/test_routing_e2e.py
+++ b/chat/tests/test_routing_e2e.py
@@ -90,3 +90,60 @@ class AgentRoutingTests(TestCase):
     def test_우주여행_비교(self):
         decision = route_question('우주여행 비용 비교')
         self.assertEqual(decision.route, ROUTE_AGENT)
+
+
+class DateConditionRoutingTests(TestCase):
+    """v0.4.2 (이슈 #73) — DATE_CONDITION_KEYWORDS 코드 fallback tier.
+
+    DB RouterRule fixture 없이 코드 키워드만으로 agent 로 라우팅되는지,
+    그리고 WORKFLOW_KEYWORDS 와 충돌하는 합성 질문에서도 DATE_CONDITION 이
+    이기는지 검증.
+    """
+
+    def test_simple_지급일(self):
+        decision = route_question('지급일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+        self.assertIn('지급일', decision.matched_rules)
+
+    def test_simple_만료일(self):
+        decision = route_question('만료일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_simple_정산일(self):
+        decision = route_question('정산일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_simple_마감일(self):
+        decision = route_question('마감일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_collision_급여_지급일(self):
+        # `급여` (WORKFLOW) + `지급일` (DATE_CONDITION) 동시 매치 — DATE_CONDITION 우선.
+        decision = route_question('26년 6월 급여 지급일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_collision_퇴직금_만료일(self):
+        decision = route_question('퇴직금 신청 만료일은?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_collision_수당_정산일(self):
+        decision = route_question('수당 정산일 알려줘')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_collision_연차_마감일(self):
+        decision = route_question('연차 신청 마감일은 며칠까지?')
+        self.assertEqual(decision.route, ROUTE_AGENT)
+        self.assertEqual(decision.reason, 'date_condition_keyword')
+
+    def test_negative_급여_얼마(self):
+        # DATE_CONDITION 미매치 — WORKFLOW 그대로 (기존 동작 유지).
+        decision = route_question('급여는 얼마야?')
+        self.assertEqual(decision.route, ROUTE_WORKFLOW)
+        self.assertEqual(decision.reason, 'workflow_keyword')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ whitenoise>=6.6
 psycopg[binary]>=3.1
 pgvector>=0.3
 openai>=1.50
+holidays>=0.50,<1.0
 pypdf>=4.2
 pdfplumber>=0.11
 pymupdf>=1.24

--- a/resources/documents/2026-04-30-fix-73-agent-calendar.md
+++ b/resources/documents/2026-04-30-fix-73-agent-calendar.md
@@ -1,0 +1,186 @@
+# 2026-04-30 개발 로그 — v0.4.2 fix #73: Agent Calendar Tool
+
+## 배경
+
+v0.4.1 운영 중 사용자 발견 회귀:
+
+```
+사용자: 26년 6월 임금 지급일은?
+봇:    6월 21일입니다. 다만, 토요일 또는 공휴일인 경우 익일에 지급됩니다.
+실제: 2026-06-21 = 일요일 → 정답은 6월 22일
+```
+
+규정 텍스트는 정확히 인용되지만 자료 안에 들어있는 **조건절 (`토/공휴일이면 익일`) 을 현재 달력에 적용해 추론하는 능력** 이 없음. 같은 패턴이 사규 곳곳에 반복 (만료일 / 정산일 / 신청 마감 / 분기 마감) 이라 패턴별 workflow 구현은 ROI 가 나쁨.
+
+이슈 #73 의 결정 (option A): **agent 에 calendar tool 추가**. 한 도구가 모든 conditional date 패턴을 흡수.
+
+플랜: `resources/plans/v_0_x/v_0_4_2/fix_73_plan.md`
+
+---
+
+## 1. 설계 결정
+
+### 1.1. 도구 시그니처 (3개)
+
+| 이름 | 입력 | 출력 (callable raw) | summary |
+|---|---|---|---|
+| `weekday_of` | `{date: str}` | `{date, weekday}` | `2026-06-21 = 일요일` |
+| `is_business_day` | `{date: str}` | `{date, weekday, is_business_day, holiday_name}` | `2026-06-06 (토요일) = 휴일 — 현충일` |
+| `next_business_day` | `{date: str}` | `{input_date, next_business_day, weekday, shifted}` | `2026-06-21 → 2026-06-22 (월요일, 다음 영업일)` |
+
+세 도구 모두 schema 모드 (`Tool.input_schema` 명시) — 단일 string `date` 필드. 입력 변형 4종 허용: `YYYY-MM-DD` / `YYYY/MM/DD` / `YYYY.MM.DD` / `YYYYMMDD`.
+
+### 1.2. `holidays` PyPI
+
+- `holidays>=0.50,<1.0` (BSD-3, 활발 유지보수)
+- `holidays.KR(language='ko')` 전역 1회 캐싱 — thread-safe, 매년 PyPI 업그레이드만으로 데이터 갱신
+- 한국어 공휴일명 (`현충일` / `삼일절` / `광복절` / `어린이날` / `추석` / `설`)
+
+### 1.3. 도구 실패 정책
+
+**`failure_kind` 분기 추가 0** — 현행 `tools.call()` 의 4분기 (`unknown_tool` / `schema_invalid` / `callable_error` / `low_relevance`) 그대로 활용:
+
+- 잘못된 date 형식 → callable 에서 `ValueError` raise → **`callable_error`**
+- 빈 문자열 / 키 누락 → schema `require_fields` 에서 차단 → **`schema_invalid`**
+- callable_error 는 `MAX_LOW_RELEVANCE_RETRIEVES` 누적 가드 미카운트 → ReAct loop 가 다른 형식으로 자유 retry
+
+이는 Codex 검토 P2-1 의 가이드 — "별 enum 추가하지 말고 현행 4분기 충분히 활용". 플랜의 가설 (`invalid_input` 신설) 은 폐기.
+
+### 1.4. 라우팅 — `DATE_CONDITION_KEYWORDS` tier 신설
+
+#### 단순 `AGENT_KEYWORDS` 확장이 안 되는 이유 (Codex P2-2)
+
+기존 `route_question()` 평가 순서:
+```
+1. DB RouterRule
+2. WORKFLOW_KEYWORDS  ← 먼저
+3. AGENT_KEYWORDS
+4. default → single_shot
+```
+
+`AGENT_KEYWORDS` 에 `지급일` 만 추가하면 `급여 지급일은?` 같은 합성 질문이 `WORKFLOW` 의 `급여` 에 가로채짐 → `route='workflow', workflow_key=''` → workflow_node 가 single_shot 으로 폴백 → calendar 도구 호출 안 됨. 동일 충돌: `퇴직금 지급일`, `수당 지급일`.
+
+#### 해결 — 전용 tier
+
+`chat/services/question_router.py` 에 `DATE_CONDITION_KEYWORDS` 신설:
+
+```python
+DATE_CONDITION_KEYWORDS: tuple[str, ...] = (
+    '지급일', '만료일', '정산일', '마감일',
+)
+```
+
+`route_question` 평가 순서:
+```
+1. DB RouterRule
+2. DATE_CONDITION_KEYWORDS → route='agent', reason='date_condition_keyword'  ← 신규
+3. WORKFLOW_KEYWORDS         → route='workflow'
+4. AGENT_KEYWORDS            → route='agent', reason='agent_keyword'
+5. default                   → route='single_shot'
+```
+
+### 1.5. 운영자 override 경로
+
+- 합성 질문을 workflow 로 보내고 싶은 경우: BO `/bo/router-rules/new/` 에서 `pattern=급여 지급일`, `route=workflow` 로 명시 등록 — DB rule 이 코드 fallback 보다 먼저 평가
+- DATE_CONDITION 키워드를 single_shot 으로 보내고 싶은 경우: 같은 방식으로 `pattern=지급일`, `route=single_shot` 등록
+
+### 1.6. BO 노출
+
+`/bo/router-rules/` 의 코드 fallback 박스에 `agent (조건절)` 카드 추가 — 운영자가 새 tier 의 존재와 4 키워드를 즉시 인지 가능. WORKFLOW / AGENT 카드와 같은 패턴.
+
+### 1.7. agent 프롬프트 가이드
+
+`assets/prompts/chat/agent_react.md` 끝에 **조건절 처리 (v0.4.2)** 문단 추가. 도구만으로는 부족 — agent 에게 "토/공휴일이면 익일" 류 발견 시 `is_business_day` / `next_business_day` 호출하라고 명시. LLM 이 자체적으로 요일 추측하지 않도록 차단.
+
+---
+
+## 2. 구현
+
+### 신규 (3)
+- `resources/plans/v_0_x/v_0_4_2/fix_73_plan.md` — 본 fix 의 detail plan
+- `chat/tests/test_agent_tools_calendar.py` — 22 cases
+- `resources/documents/2026-04-30-fix-73-agent-calendar.md` — 본 dev log
+
+### 수정 (5)
+- `requirements.txt` — `holidays>=0.50,<1.0` 추가
+- `chat/services/agent/tools_builtin.py` — 3 callable + summarize + register 블록 (181 lines 추가)
+- `assets/prompts/chat/agent_react.md` — 조건절 처리 가이드 7줄
+- `chat/services/question_router.py` — `DATE_CONDITION_KEYWORDS` 상수 + `route_question` 평가 순서 확장
+- `bo/views/router_rules.py` + `bo/templates/bo/router_rules.html` — DATE_CONDITION 카드 노출
+- `chat/tests/test_routing_e2e.py` — 9 cases 추가 (단순 4 + 충돌 4 + 음성 1)
+
+### 마이그레이션 / DB 변경
+**0건.** 코드 상수 + 도구 등록만으로 해결.
+
+---
+
+## 3. 검증
+
+### 자동 (CI)
+```
+$ docker compose exec -T web python manage.py test
+Ran 551 tests in 1.147s
+OK
+```
+
+523 (v0.4.1) → 551 (+28 신규: calendar 22 + 라우팅 9 ⊃ 기존 통과 그대로).
+
+### 수동 (도구 smoke)
+```
+weekday_of({'date': '2026-06-21'}) → 2026-06-21 = 일요일
+is_business_day({'date': '2026-06-21'}) → 2026-06-21 (일요일) = 휴일 (주말)
+is_business_day({'date': '2026-06-06'}) → 2026-06-06 (토요일) = 휴일 — 현충일
+next_business_day({'date': '2026-06-21'}) → 2026-06-21 → 2026-06-22 (월요일, 다음 영업일)
+weekday_of({'date': '2026.06.21'}) → 2026-06-21 = 일요일  (alt 형식 OK)
+weekday_of({'date': 'invalid'}) → callable_error: ValueError ...
+```
+
+### 수동 (라우팅 smoke)
+```
+'지급일은?'         → route=agent reason=date_condition_keyword matched=['지급일']
+'급여 지급일은?'    → route=agent reason=date_condition_keyword matched=['지급일']  ← WORKFLOW '급여' 가 가로채지 못함
+'급여는 얼마야?'    → route=workflow reason=workflow_keyword matched=['얼마','급여']  ← 음성 케이스 보호
+```
+
+### 수동 (BO 페이지)
+- `http://localhost:8001/bo/router-rules/` HTTP 200
+- "기본 키워드" 박스 안에 `agent (조건절)` 카드 + 4 키워드 (`지급일/만료일/정산일/마감일`) + "WORKFLOW 보다 먼저 평가 (v0.4.2)" 노트 visible
+
+---
+
+## 4. 한계 / 후속
+
+### 한계
+- `holidays` PyPI 의 임시공휴일은 행정안전부 발표 직후엔 lag 가능 — 발견 시 패키지 업그레이드로 해결
+- 회사별 custom 휴일 (창립기념일 등) 미지원 — 사규에 자체 명시되어 있어도 calendar tool 은 표준 한국 공휴일만 봄
+- agent 가 calendar 도구를 안 쓰고 LLM 직접 요일 판단할 위험 → 프롬프트 가이드로 차단, 회귀 시 BO Prompt 관리에서 즉시 보강
+- 이번 fix 는 agent 경로 한정 — single_shot 으로 가는 동일 질문엔 calendar reasoning 없음. 운영자가 BO 에서 RouterRule 명시 등록하면 우회 가능
+
+### 후속 (out of scope, 별 이슈)
+- 회사별 custom 휴무일 BO 등록 UI
+- 결정론적 `payday_calculation` workflow (option B) — calendar tool 사용량 6개월 관찰 후 재검토
+- v0.5.0 LLM 기반 라우터 — keyword 기반 routing 의 본질적 한계 해결 (별 milestone)
+
+---
+
+## 5. 릴리즈
+
+본 fix 는 v0.4.2 패치 릴리즈 (PATCH bump):
+
+```
+v0.4.1 → v0.4.2
+```
+
+흐름:
+1. fix/#73 → develop merge
+2. develop → main release PR (chore: Release v0.4.2)
+3. tag v0.4.2 + push → GHCR 운영 배포
+4. 사용자가 운영에서 `26년 6월 임금 지급일은?` 시 정답 (6월 22일) 답변 확인
+
+---
+
+## 6. 참고
+
+- 이슈: https://github.com/SEAN-59/Personal_AI_Chat/issues/73
+- 플랜: `resources/plans/v_0_x/v_0_4_2/fix_73_plan.md`
+- Codex 검토 (3 라운드): P2 invalid_input / P2 RouterRule seed / P3 정산일 / P3 신규 file count / P2 routing precedence / P3 BO visibility / P3 test count — 모두 plan 단계에서 반영 후 구현

--- a/resources/plans/v_0_x/v_0_4_2/fix_73_plan.md
+++ b/resources/plans/v_0_x/v_0_4_2/fix_73_plan.md
@@ -1,0 +1,314 @@
+# v0.4.2 — fix #73: Agent Calendar Tool 개발 플랜
+
+## Context
+
+v0.4.1 운영 중 사용자 발견 회귀:
+
+```
+사용자: 26년 6월 임금 지급일은?
+봇:    6월 21일입니다. 다만, 토요일 또는 공휴일인 경우 익일에 지급됩니다.
+실제: 2026-06-21 = 일요일 → 정답은 6월 22일
+```
+
+규정 텍스트는 정확히 인용되지만, 자료 안에 들어있는 **조건절 (`토/공휴일이면 익일`) 을 현재 달력에 적용해 추론하는 능력** 이 없음. 같은 패턴이 사규 곳곳에 반복 (만료일 / 정산일 / 신청 마감 / 분기 마감) 이라 패턴별 workflow 구현은 ROI 가 나쁨.
+
+이슈 #73 (`fix:` / `type: bug` / `0.x Maintenance` milestone) 의 결정 사항:
+
+> **Option A — agent 에 calendar tool 추가**. 임금/만료/정산 등 모든 conditional date 패턴을 한 도구로 흡수.
+
+본 plan 은 v0.4.2 patch release 단위로 처리 — `fix` 만 포함 → SemVer PATCH 상승.
+
+---
+
+## Scope
+
+**포함**
+- `chat/services/agent/tools_builtin.py` — 3개 도구 신규 등록:
+  - `weekday_of(date) -> '월'/'화'/.../'일'`
+  - `is_business_day(date) -> bool` (주말 + 한국 공휴일)
+  - `next_business_day(date) -> 'YYYY-MM-DD'`
+- `requirements.txt` — `holidays` PyPI 의존성 추가
+- `assets/prompts/chat/agent_react.md` — conditional date clause 인식 시 calendar tool 호출 가이드 추가
+- `chat/services/question_router.py` — `DATE_CONDITION_KEYWORDS` 신설 (`지급일` / `만료일` / `정산일` / `마감일`) + `route_question` 의 평가 순서를 `DB rule → DATE_CONDITION → WORKFLOW → AGENT → default` 로 확장. WORKFLOW 보다 먼저 평가해 `급여 지급일` 같은 합성 질문이 `급여` (WORKFLOW_KEYWORDS) 에 가로채지지 않도록.
+- `bo/views/router_rules.py` + `bo/templates/bo/router_rules.html` — 코드 fallback 키워드 박스에 `DATE_CONDITION_KEYWORDS` 섹션 신설 (운영자가 새 tier 의 존재를 BO 에서 인지 가능하도록).
+- 단위 테스트 (`chat/tests/test_agent_tools_calendar.py`) — 3 도구 각 1~2건
+- 통합 테스트 — agent E2E 시나리오 (임금 지급일 query → calendar tool 호출 → 정답)
+- Dev log `resources/documents/2026-04-XX-fix-73-agent-calendar.md`
+- 본 plan 문서 자체 (`resources/plans/v_0_x/v_0_4_2/fix_73_plan.md`)
+
+**제외 (이번 patch 범위 밖)**
+- 회사별 custom 공휴일 / 임시공휴일 추가 (PyPI `holidays` 의 standard Korean public holidays 만)
+- 결정론적 workflow 도메인 (option B — 충분히 안 쓰이면 영원히 도입 안 함)
+- 시스템 프롬프트 (`system.md`) 수정 — single_shot 경로엔 calendar 능력 없음, agent 만 처리
+- LLM router (Phase 10 / v0.5.0) — 별 milestone
+- 도구의 BO 노출 (`/bo/agent/` tool catalog 는 자동 반영되니 코드 변경 0)
+
+---
+
+## git-flow 계획
+
+- **Milestone**: `0.x Maintenance` (이미 #9 로 존재)
+- **Issue**: #73 (이미 존재 — Step 0 에서 타이틀/라벨만 `fix:` / `type: bug` 로 재분류)
+- **Branch**: `fix/#73-agent-calendar-tool`, `develop` 에서 분기
+- **PR 단위**: **단일 PR**. 도구 / 프롬프트 / 라우터 키워드 / 테스트 / 문서가 하나의 fix unit. 커밋은 아래 6 단계로 쪼개 히스토리 가독성 확보.
+- **Conventional Commits**: 모든 커밋 prefix `fix:` (단 `test:` / `docs:` 는 그 자체로 fix 의 부속이라 PR 전체 머지 결과는 PATCH 로 정합).
+- **Release**: develop merge → develop → main 정기 배포 PR → tag `v0.4.2` → main 백머지
+
+> 사용자 명시 정책: 이 patch 는 v0.4.2 로 즉시 cut. v0.5.0 (LLM router) 와 분리.
+
+---
+
+## 핵심 설계 결정
+
+### 1. 도구 시그니처 (3개)
+
+| 이름 | 입력 | 출력 | 비고 |
+|---|---|---|---|
+| `weekday_of` | `date: 'YYYY-MM-DD'` | `'월'/'화'/'수'/'목'/'금'/'토'/'일'` | 단순 요일 |
+| `is_business_day` | `date: 'YYYY-MM-DD'` | `true / false` | 주말 또는 한국 공휴일이면 `false` |
+| `next_business_day` | `date: 'YYYY-MM-DD'` | `'YYYY-MM-DD'` | `date` 가 영업일이면 그대로, 아니면 다음 영업일 |
+
+세 도구 모두 schema 모드 (`Tool.input_schema` 명시). 입력은 단일 string `date` 필드로 통일 — agent 가 `arguments={"date": "2026-06-21"}` 형태로 호출. 잘못된 형식은 callable 에서 `ValueError` 를 던져 현행 `tools.call()` 의 `failure_kind='callable_error'` 분기에 흡수 (별 enum 추가 X — agent 동작상 callable_error 면 ReAct loop 가 다음 iteration 에 다른 입력 시도하므로 충분).
+
+### 2. `holidays` PyPI 사용
+
+- `pip install holidays` (BSD-3, 활발히 유지보수, 한국 공휴일 정확)
+- 사용 예: `import holidays; KR = holidays.KR(); date(2026,6,6) in KR  # True (현충일)`
+- 매년 update 필요 — `holidays` 패키지가 자체적으로 업데이트되므로 운영 부담 0
+- 임시공휴일은 한국 행정안전부 발표를 PyPI 가 잡아주지만 발표 직후엔 lag 가능 — 발견 시 패키지 업그레이드로 해결
+
+### 3. agent prompt 변경 최소
+
+`agent_react.md` 끝에 한 문단 추가:
+
+> **조건절 처리 (Phase 0.4.2)**: retrieve 결과에 "토요일/일요일/공휴일이면 익일" 같은 조건절이 보이고 사용자 질문이 특정 날짜를 묻고 있다면, `is_business_day` 또는 `next_business_day` 도구로 실제 적용 결과를 계산해 답변에 반영. 도구 없이 LLM 이 직접 요일을 판단하지 말 것.
+
+`build_messages` 의 tool catalog 에는 자동 노출되므로 별 변경 X.
+
+### 4. 라우팅 키워드 — `DATE_CONDITION_KEYWORDS` 신설 + 평가 우선순위 변경
+
+#### 4-1. 단순 `AGENT_KEYWORDS` 확장이 안 되는 이유 (Codex 검토 P2)
+
+`route_question()` 의 현행 평가 순서 (`chat/services/question_router.py:107-129`):
+
+```
+1. DB RouterRule
+2. WORKFLOW_KEYWORDS (코드 fallback)   ← 먼저
+3. AGENT_KEYWORDS (코드 fallback)
+4. default → single_shot
+```
+
+`AGENT_KEYWORDS` 에 `지급일` 만 추가하면 `급여 지급일은?` 같은 **합성 질문** 이 `WORKFLOW_KEYWORDS` 의 `급여` 에 먼저 가로채짐 → `route='workflow', workflow_key=''` → workflow_node 가 single_shot 으로 폴백 → calendar 도구 호출 안 됨. 동일 충돌: `퇴직금 지급일`, `수당 지급일`.
+
+#### 4-2. 해결 — 전용 tier 신설
+
+`chat/services/question_router.py` 에 **`DATE_CONDITION_KEYWORDS`** 상수 신설하고 평가 순서에 끼워넣음:
+
+```python
+# 조건절 (토/공휴일 익일 등) 적용이 필요한 질문 신호.
+# WORKFLOW_KEYWORDS 보다 먼저 평가 — `급여 지급일` 같은 합성 질문이 `급여`
+# (WORKFLOW) 에 먼저 가로채지지 않도록. v0.4.2 신규 (이슈 #73).
+DATE_CONDITION_KEYWORDS: tuple[str, ...] = (
+    '지급일', '만료일', '정산일', '마감일',
+)
+```
+
+`route_question` 평가 순서 (변경 후):
+
+```
+1. DB RouterRule
+2. DATE_CONDITION_KEYWORDS  → route='agent', reason='date_condition_keyword'   ← 신규
+3. WORKFLOW_KEYWORDS         → route='workflow'
+4. AGENT_KEYWORDS            → route='agent', reason='agent_keyword'
+5. default                   → route='single_shot'
+```
+
+#### 4-3. 왜 `AGENT_KEYWORDS` 와 분리하는가
+
+- **시멘틱 분리**: `비교/추천/유리` 같은 "추론 의도" 와 `지급일/만료일` 같은 "조건절 적용 필요" 는 의미가 다름 — 한 통에 섞으면 후속 추가/제거 시 의도 혼동
+- **다른 우선순위**: WORKFLOW_KEYWORDS 와 충돌 시 어느 쪽이 이겨야 하는지가 두 카테고리 다름 — DATE_CONDITION 은 이겨야 하고, AGENT_KEYWORDS 는 그대로 (기존 정책 유지)
+- **로그 가독성**: `reason='date_condition_keyword'` 가 `reason='agent_keyword'` 보다 진단 정보가 풍부 — 운영자가 이 라우팅이 calendar 의도였음을 즉시 식별
+- **확장성**: 향후 다른 "조건 적용 필요" 패턴 (예: `시효`, `유효기간`) 도 같은 tier 에 자연스럽게 추가
+
+#### 4-4. 운영자 override 경로
+
+- 운영자가 `pattern=급여 지급일`, `route=workflow` 같이 명시 등록하면 DB RouterRule 이 코드 fallback 보다 먼저 평가되므로 즉시 우선
+- DATE_CONDITION 으로 보내고 싶지 않은 케이스도 BO 에서 explicit override 가능
+- 운영 데이터 / dev log 에 이 관계 명시
+
+### 5. 도구 실패 정책
+
+- 잘못된 date 문자열 (parsing 불가) → callable 에서 `ValueError('invalid date format: ...')` raise → 현행 `tools.call()` 의 `failure_kind='callable_error'` 로 흡수 (Phase 7-4 분기 4종: `unknown_tool` / `schema_invalid` / `callable_error` / `low_relevance` 그대로 사용 — 새 enum 추가 X)
+- 누적 가드는 `low_relevance` 만 카운트 (Phase 7-4 정책) 이라 callable_error 는 max_iter 안에서 자유롭게 재시도 가능 — agent 가 다른 형식 (`2026.06.21` → `2026-06-21`) 으로 retry
+- `holidays` 라이브러리 자체 실패 (네트워크 X, 순수 in-memory 라 거의 없음) → fallback: 주말 판단만 하고 공휴일은 "확인 필요" 안내
+- `is_business_day` / `next_business_day` 의 결과는 agent 의 final answer 에 직접 반영
+
+### 6. 테스트 전략
+
+- 단위 테스트 (`test_agent_tools_calendar.py`) — 3 도구 입력/출력 + 잘못된 입력 → `tools.call()` Observation 에서 `failure_kind='callable_error'` 확인 + 한국 공휴일 정확성 (현충일 / 어린이날 / 광복절)
+- 라우팅 테스트 — `chat/tests/test_routing_e2e.py` 에:
+  - 단순 케이스 4건: `지급일은?` / `만료일은?` / `정산일은?` / `마감일은?` → 모두 `route=agent`, `reason='date_condition_keyword'`
+  - **충돌 케이스** 4건: `급여 지급일은?` (WORKFLOW `급여` 와 DATE_CONDITION `지급일` 동시 매치 — agent 가 이겨야 함), `퇴직금 만료일은?`, `수당 정산일은?`, `연차 마감일은?` — `DATE_CONDITION_KEYWORDS` 우선 평가 검증
+  - 음성 케이스: `급여는 얼마야?` → `route=workflow` (DATE_CONDITION 미매치, WORKFLOW `얼마` 매치 — 기존 동작 유지)
+- 통합 테스트 — 임금 지급일 시나리오를 mock retrieve 결과 + LLM stub 으로 ReAct loop 한 번 돌려 calendar tool 호출 추적
+- E2E (수동) — 운영 PDF 환경에서 `2026년 6월 임금 지급일은?` 실제 답변 확인
+
+---
+
+## 구현 순서 (커밋 6개)
+
+### Step 0 — Issue 재분류 (코드 변경 X)
+- `gh issue edit 73 --title "fix: ..."` + label `type: bug`
+- 메모리 / plan 변경 없음
+
+### Step 1 — 의존성 + plan 문서 커밋
+- `requirements.txt` 에 `holidays` 추가 (latest minor pin: `holidays>=0.50,<1.0`)
+- 본 plan 문서 자체 add
+
+**커밋**: `fix: Add holidays dependency and plan doc for #73 (#73)`
+
+### Step 2 — 3 calendar 도구 구현 + 등록
+- `chat/services/agent/tools_builtin.py` 에 3 callable + `register(Tool(...))` 3 블록 추가
+- 입력 검증 + 한국 공휴일 처리
+
+**커밋**: `fix: Add weekday_of / is_business_day / next_business_day tools (#73)`
+
+### Step 3 — agent prompt 가이드 추가
+- `assets/prompts/chat/agent_react.md` 끝에 conditional clause 처리 문단 추가
+
+**커밋**: `fix: Guide agent to use calendar tools for conditional date clauses (#73)`
+
+### Step 4 — `DATE_CONDITION_KEYWORDS` 신설 + 평가 우선순위 변경 + BO 노출
+- `chat/services/question_router.py` 변경:
+  - `DATE_CONDITION_KEYWORDS` 상수 신설 (`지급일 / 만료일 / 정산일 / 마감일`)
+  - `route_question()` 평가 순서: DB rule → **DATE_CONDITION** → WORKFLOW → AGENT → default
+  - `RouteDecision.reason` 신규 값: `'date_condition_keyword'`
+- BO 노출:
+  - `bo/views/router_rules.py` — `DATE_CONDITION_KEYWORDS` import + context 에 `date_condition_keywords` 키로 전달
+  - `bo/templates/bo/router_rules.html` — 코드 fallback 박스에 `DATE_CONDITION` 섹션 신설 (`workflow_keywords` / `agent_keywords` 섹션과 동일 패턴)
+- 마이그레이션 / DB 변경 0 — 코드 상수 + 함수 흐름 + BO 표시만 수정
+
+**커밋**: `fix: Add DATE_CONDITION_KEYWORDS tier to route calendar queries to agent (#73)`
+
+### Step 5 — 테스트
+- `chat/tests/test_agent_tools_calendar.py` 신규 (단위)
+- `chat/tests/test_agent_calendar_e2e.py` 신규 (통합 — 임금 지급일 시나리오)
+
+**커밋**: `test: Cover calendar tools and conditional date e2e (#73)`
+
+### Step 6 — Dev log
+- `resources/documents/2026-04-XX-fix-73-agent-calendar.md`
+- 사용자 회귀 사례 / 설계 결정 / 구현 / 검증 / 한계
+
+**커밋**: `docs: Document agent calendar tool fix (#73)`
+
+---
+
+## 파일 변경 요약
+
+### 신규 (4)
+```
+chat/tests/test_agent_tools_calendar.py
+chat/tests/test_agent_calendar_e2e.py
+resources/documents/2026-04-XX-fix-73-agent-calendar.md
+resources/plans/v_0_x/v_0_4_2/fix_73_plan.md   # 본 문서
+```
+
+### 수정 (7)
+```
+chat/services/agent/tools_builtin.py        # 3 도구 callable + register
+assets/prompts/chat/agent_react.md          # conditional clause 가이드
+chat/services/question_router.py            # DATE_CONDITION_KEYWORDS 신설 + 평가 순서 변경
+chat/tests/test_routing_e2e.py              # 단순 키워드 4건 + 합성 충돌 케이스 + 음성 케이스 (총 9 case 추가)
+bo/views/router_rules.py                    # DATE_CONDITION_KEYWORDS context 전달
+bo/templates/bo/router_rules.html           # 코드 fallback 박스에 DATE_CONDITION 섹션 추가
+requirements.txt                             # +holidays
+```
+
+### 삭제 (없음)
+
+---
+
+## 주요 파일 경로 (reference)
+
+**현 상태 (v0.4.1)**
+- `chat/services/agent/tools_builtin.py:364-403` — 기존 3 도구 register 위치. 새 도구 3개 같은 컨벤션 추가
+- `chat/services/agent/tools.py` — `Tool` dataclass + `register()` API
+- `chat/services/agent/react.py` — ReAct loop. 도구 추가만 하면 자동 활용 (catalog 자동 빌드)
+- `chat/services/agent/state.py` — `Observation` / `failure_kind` 정의. 현행 4분기 (`unknown_tool` / `schema_invalid` / `callable_error` / `low_relevance`) 그대로 사용
+- `chat/services/question_router.py:38-51` — `WORKFLOW_KEYWORDS` / `AGENT_KEYWORDS` 코드 상수. 본 fix 에서 `DATE_CONDITION_KEYWORDS` 신설을 같은 영역에 추가
+- `chat/services/question_router.py:107-129` — `route_question()` 본체. 평가 순서 변경 위치
+- `assets/prompts/chat/agent_react.md` — agent system prompt
+- `requirements.txt` — `chat/` 패키지 의존성
+
+**재사용**
+- `chat.services.agent.tools.register` / `Tool` / `FieldSpec` — 도구 등록 인프라
+- 한국 공휴일은 `holidays.KR` 인스턴스 캐싱 (전역 1회 생성, thread-safe)
+
+---
+
+## 검증
+
+### 자동 (CI)
+```bash
+docker compose exec -T web python manage.py check
+docker compose exec -T web python manage.py test --verbosity 0
+```
+- 기존 523 + 신규 ~14 → 537 전후 그린 기대 (calendar 단위 + 라우팅 e2e 8~9 (단순 4 + 충돌 4 + 음성 1) + 통합 e2e)
+
+### 수동 (E2E)
+1. 채팅 페이지에서 `26년 6월 임금 지급일은?` 입력
+2. 서버 로그 확인:
+   - `라우팅: route=agent reason=date_condition_keyword matched_rules=['지급일']` (코드 fallback 매치)
+     - 운영자가 BO 에 명시 rule 을 등록한 환경이면 `reason=db_rule:<name>` 로 표시
+   - `ReAct iteration 1/6 ...` retrieve_documents 호출
+   - `ReAct iteration 2/6 ...` `is_business_day` 또는 `next_business_day` 호출 (date='2026-06-21')
+   - `final_answer` 에 "6월 22일" 포함
+3. BO `/bo/agent/` 의 최근 7일 호출 통계에 새 tool 등장
+4. BO `/bo/` 대시보드 Purpose 별 사용량에 `agent_step` row 증가
+5. BO `/bo/router-rules/` — 코드 fallback 키워드 박스 안에 `DATE_CONDITION_KEYWORDS` 4건 visible 확인 (별 섹션 또는 AGENT 섹션 위에 표시)
+6. **충돌 검증**: `급여 지급일은?` 입력 → 로그에 `route=agent reason=date_condition_keyword matched_rules=['지급일']` (WORKFLOW `급여` 가 가로채지 않음을 확인)
+
+### 회귀 민감 포인트
+- [ ] 기존 agent E2E (`본인 결혼 경조금 비교`) 변경 없음 — calendar 도구 미호출 confirm
+- [ ] `holidays` import 실패 시 (테스트 환경) graceful fallback 동작
+- [ ] 운영자가 등록한 기존 RouterRule 과 충돌 0 (DB 변경 0)
+- [ ] `routing_e2e` 의 기존 9 case 그대로 통과 — **신규 9 case 추가** (단순 4 + 합성 충돌 4 + 음성 1)
+- [ ] BO `/bo/router-rules/` 코드 fallback 박스에 `DATE_CONDITION` 섹션 4 키워드 visible (view + template 함께 수정)
+
+---
+
+## 리스크 & 대응
+
+| 리스크 | 대응 |
+|---|---|
+| `holidays` 패키지 임시공휴일 lag | 운영자가 BO 에서 사후 보정 안내 + 패키지 업그레이드 정책 (분기 1회) |
+| agent 가 calendar 도구를 안 쓰고 LLM 직접 요일 판단 | 프롬프트 가이드 강화 (Step 3) + 회귀 시 `agent_react.md` BO 편집으로 즉시 보강 |
+| `DATE_CONDITION_KEYWORDS` 가 WORKFLOW 보다 먼저 평가됨 — 기존 의도와 충돌 가능 | (a) routing_e2e 회귀로 기존 9 case 보호, (b) 신규 키워드 4개 (`지급일/만료일/정산일/마감일`) 는 단독으로 등장 시 거의 항상 calendar 의도라 false positive 낮음, (c) BO RouterRule 로 explicit override 가능 — DB rule 이 모든 코드 fallback 보다 먼저 평가됨 |
+| 운영자가 합성 질문 (`급여 지급일`) 을 workflow 로 보내고 싶을 때 | BO `/bo/router-rules/new/` 에서 `pattern=급여 지급일`, `route=workflow`, `workflow_key=...` 로 명시 등록 — DB rule 이 즉시 우선 |
+| 운영자가 calendar 키워드를 single_shot 으로 보내고 싶을 때 | BO `/bo/router-rules/new/` 에서 `pattern=지급일`, `route=single_shot` 으로 명시 rule 등록 — 코드 fallback 보다 우선 평가 |
+| 도구 추가로 agent token 비용 ↑ | 도구 catalog 1 줄씩 추가 — 호출당 +50~100 token. 1000 q/day → +$0.005/day. 무시 가능 |
+| date 문자열 형식 불일치 (`2026.06.21` vs `2026-06-21`) | 도구 callable 진입부에서 `dateutil.parser.parse` 로 normalize. 실패 시 `ValueError` → `callable_error` 로 ReAct loop 재시도 |
+| 한국 공휴일 데이터 정확성 (현충일/광복절/추석/설) | PyPI `holidays` 의 KR 검증 + 단위 테스트로 매년 변동 공휴일 (추석/설) 1~2건 픽스 |
+
+---
+
+## Out of Scope (별도 이슈로 처리)
+
+- 회사별 custom 휴무일 (창립기념일 등) BO 등록 UI
+- 다국가 공휴일 (`holidays` 는 멀티국가 지원하지만 KR 만 사용)
+- `payday_calculation` 결정론적 workflow (option B) — calendar tool 사용량 보고 6개월 후 재검토
+- BO `/bo/agent/` 의 tool catalog 에 도구 설명 한국어화 (현재 영문 description 그대로) — UX 개선 별 이슈
+- Phase 10 LLM router 와의 통합 — calendar tool 은 agent 도구라 router 변경과 직교
+
+---
+
+## 참고 — v0.5.0 와의 관계
+
+본 fix 는 v0.5.0 (LLM router) 와 **독립적**.
+
+- calendar tool 은 agent 도구 확장 — router 변경과 무관
+- v0.5.0 에서 LLM router 가 도입돼도 본 도구는 그대로 활용
+- 본 patch 가 먼저 나가도 v0.5.0 개발에 영향 0
+
+따라서 v0.5.0 일정과 무관하게 v0.4.2 cut.


### PR DESCRIPTION
## Summary

v0.4.1 운영 회귀 — 자료의 conditional date clause ("토/공휴일이면 익일")를 실제 달력에 적용하지 못해 잘못된 답변. 사용자 발견 사례:

```
사용자: 26년 6월 임금 지급일은?
v0.4.1 봇: 6월 21일 (다만 토/공휴일이면 익일)   ← 21일은 일요일, 정답은 22일
v0.4.2 봇: 6월 22일 (월요일)                    ← 정답
```

이슈 #73 의 결정 (option A) — agent 에 calendar tool 추가. 임금/만료/정산/마감 등 모든 conditional date 패턴을 한 도구로 흡수.

## Changes

### Agent calendar tools (`chat/services/agent/tools_builtin.py`)
- `weekday_of(date)` — 한국어 한 글자 요일 반환
- `is_business_day(date)` — 영업일 여부 + 한국 공휴일명 (한국어)
- `next_business_day(date)` — 영업일이면 그대로, 아니면 다음 영업일
- `holidays.KR(language='ko')` 전역 캐싱 (thread-safe, 매년 PyPI 업그레이드만)
- 입력 형식 4종 (`YYYY-MM-DD` / `YYYY/MM/DD` / `YYYY.MM.DD` / `YYYYMMDD`)
- 잘못된 입력은 ValueError → tools.call() 의 callable_error 분기 (failure_kind enum 추가 0)

### Routing — `DATE_CONDITION_KEYWORDS` tier (`chat/services/question_router.py`)
- 단순 `AGENT_KEYWORDS` 확장은 합성 질문 충돌 (`급여 지급일은?` → WORKFLOW `급여` 가 가로챔)
- 신설 `DATE_CONDITION_KEYWORDS = ('지급일', '만료일', '정산일', '마감일')` + `route_question()` 평가 순서 변경: DB rule → **DATE_CONDITION** → WORKFLOW → AGENT → default
- 운영자가 BO 에서 RouterRule 명시 등록 시 그게 우선 (DB > 코드 fallback)

### Agent prompt (`assets/prompts/chat/agent_react.md`)
- "조건절 처리" 가이드 추가 — 자료에서 "토/공휴일이면 익일" 발견 시 calendar 도구 호출하라고 명시. LLM 이 자체 요일 추측 차단

### BO routing visibility (`bo/views/router_rules.py` + `bo/templates/bo/router_rules.html`)
- `/bo/router-rules/` 의 코드 fallback 박스에 `agent (조건절)` 카드 신설 — 운영자가 새 tier 인지

### RouterRule duplicate prevention (`bo/views/router_rules.py`)
- 검증 부산물 — 운영자가 같은 `(pattern, match_type)` 의 rule 을 두 번 등록할 수 있던 함정 ("며칠" rule 두 개 등록되어 있던 사례) 차단
- `RouterRuleForm.clean()` 에 검증 + 친절한 에러 메시지 + 5 단위 테스트

### Tests (`chat/tests/`)
- `test_agent_tools_calendar.py` — 22 cases (3 도구 × 입력 형식 / 한국 공휴일 / 영업일 / 음성 / schema 검증)
- `test_routing_e2e.py` — 9 cases 추가 (단순 4 + 합성 충돌 4 + 음성 1)
- `bo/tests.py` `RouterRuleFormDuplicatePreventionTests` — 5 cases

총 **523 → 556 (+33 신규)**, 모두 그린.

### Dependency
- `holidays>=0.50,<1.0` — 한국 공휴일 데이터 (BSD-3, pure Python, 매년 업그레이드)

### Migration / DB changes
**0건.** 코드 상수 + 도구 등록 + 폼 검증만으로 해결.

## Codex review (3 rounds, 7 findings)
- P2 invalid_input failure kind → callable_error 흡수로 변경
- P2 RouterRule seed migration → AGENT_KEYWORDS / DATE_CONDITION_KEYWORDS 코드 fallback 으로 대체
- P3 정산일 누락 → DATE_CONDITION_KEYWORDS 에 포함
- P3 신규 file count → plan 정정
- P2 routing precedence (`급여 지급일`) → DATE_CONDITION tier 신설 (WORKFLOW 보다 먼저)
- P3 BO visibility → bo/views/router_rules.py + 템플릿 함께 수정
- P3 test count → 단순 4 + 충돌 4 + 음성 1 명시

## Verification scenarios (사용자 검증 결과)
- A. RouterRule 중복 방지 — OK
- B. 핵심 회귀 (임금 지급일 22일) — OK
- C. 라우팅 우선순위 (4건 모두 agent) — OK
- D. 음성 회귀 (workflow / single_shot 정상) — OK
- E. BO 페이지 카드 — OK
- F. Calendar 도구 직접 — OK

## Out of scope (별 이슈)
- #76 — 가정형 질문 처리 (low)
- #77 — 후속 질문 history-blind 라우팅 (medium, v0.5.0 후보)

Closes #73