### PR TITLE
fix: Preserve follow-up question context (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ Django · PostgreSQL(pgvector) · OpenAI를 결합한 개인 문서 Q&A 챗봇�
 - `AgentSettings` / `AgentSettingsAudit` — agent 한도·kill switch 싱글톤 + 변경 이력.
 
 **서비스 레이어**
-- `single_shot/` — 자료 검색 → 프롬프트 조립 → LLM 호출 → 후처리의 단일 응답 경로. 후속 질문은 진입 시 `query_rewriter` 가 self-contained 검색어로 변환 (원본 질문은 LLM · ChatLog 에 그대로 유지).
+- `single_shot/` — 자료 검색 → 프롬프트 조립 → LLM 호출 → 후처리의 단일 응답 경로. 후속 질문은 진입 시 `query_rewriter` 가 self-contained 검색어로 변환 (원본 질문은 LLM · ChatLog 에 그대로 유지). v0.5.0 부터 가설/전제 (`만약`, 숫자/기간 조건) 는 rewrite 에 보존.
+- `llm_router` — v0.5.0 신규. 키워드로 잡히지 않는 의도(가설/메타-요청/대명사) 를 보조 LLM 으로 분류. route 만 반환하고 `workflow_key` 는 손대지 않음 — DB `RouterRule` 전담.
 - `workflows/` — 결정론적 계산 경로. 공통 helper(날짜·숫자·검증·결과 타입) + 도메인 workflow. 현재 `date_calculation` (날짜 차이) / `amount_calculation` (금액 합계·평균·차이) / `table_lookup` (표 셀 조회) 3종. 자연어 질문에서 `workflow_input_extractor` (regex 우선 + LLM fallback) 가 입력값을 자동 추출. `workflow_key` 미등록 / 입력 부족 등 실패는 single_shot 폴백.
 - `agent/` — ReAct loop 기반 multi-hop 경로. 등록된 도구 (자료 검색 / 공식 Q&A 조회 / workflow 호출) 를 반복 호출하며 비교형·다중 출처형 질문 처리. 검색 결과는 query 키워드 주변 윈도우로 추려 LLM 토큰을 절약하고, 무관 청크는 `[관련성 낮음]` 마커로 표시. 종료 정책 (반복 횟수 / 연속 실패 / 동일 호출 반복 / 누적 low-relevance 한도) 과 kill switch 는 BO `/bo/agent/` 에서 제어.
 - `graph/` — LangGraph 진입점. `run_chat_graph(question, history)` → router → `(single_shot / workflow / agent)`.
-- `question_router` — 질문을 세 경로 중 하나로 분류. **DB `RouterRule` 우선 조회 → 코드 키워드 fallback → `single_shot`**. BO `/bo/router-rules/` 에서 운영자가 CRUD.
+- `question_router` — 질문을 세 경로 중 하나로 분류. **4-tier**: (1) DB `RouterRule`, (2) `DATE_CONDITION_KEYWORDS` (지급일·만료일·정산일·마감일 → agent + calendar 도구, v0.4.2 회귀 보호), (3) `llm_router` (보조 LLM 분류, route 만 채움), (4) 코드 키워드 fallback (WORKFLOW/AGENT/`single_shot`). BO `/bo/router-rules/` 에서 운영자가 CRUD.
 - `prompt_loader` / `prompt_registry` — `assets/prompts/chat/` 외부 파일 로더 + BO 편집 허용 목록.
 - `qa_retriever` — CanonicalQA 벡터 검색 + ChatLog 저장 (중복 방지) + 승격 처리.
 - `reranker` — 하이브리드 검색 결과 top 10 을 LLM 이 다시 정렬해 top 5 채택.
@@ -231,6 +232,7 @@ pending → processing → reviewing → processing → ready
 
 사용자가 질문을 보내면 다음 순서로 처리됩니다.
 
+0. **라우팅** — `question_router` 가 4-tier (DB `RouterRule` → `DATE_CONDITION_KEYWORDS` → `llm_router` → 코드 키워드 fallback) 로 `single_shot / workflow / agent` 중 하나를 결정. `workflow_key` 는 DB rule 만 채우고, LLM 출력은 route 만 사용.
 1. **세션 히스토리 로드** — Django 세션에서 최근 대화 턴(최대 20개)을 가져와 맥락 유지.
 2. **자료 후보 검색** — 하이브리드 검색(벡터 + 키워드 + RRF)으로 DocumentChunk 상위 10개 후보 선정.
 3. **LLM 재정렬** — 후보 10개를 gpt-4o-mini가 관련성 기준으로 다시 순위. 상위 5개만 최종 채택.
@@ -447,3 +449,4 @@ DB는 Docker Compose가 자동으로 기동·연결하므로 **기본 사용엔 
 |2026.04.29| 0.4.0 Phase 8-6 — Agent Settings Expansion: Extra Limits & Audit Log<br>`AgentSettings` 에 `max_consecutive_failures` (1~10) / `max_repeated_call` (**2~10**) 두 필드 추가 — `react.py` 의 코드 상수 두 개를 `runtime_settings.DEFAULT_*` alias 로 변경, `_decide_termination` 시그니처 확장. `max_repeated_call=1` 은 첫 정상 tool call 직후 종료 충돌이라 min=2 강제 + help_text 에 호환/기록용 안내 명시 (8-3 즉시 차단 정책으로 실제 동작 변화 거의 없음 — 정책 통합은 후속 Phase). 신규 `AgentSettingsAudit` 모델 — `changed_at / changed_by FK SET_NULL / changes JSON / snapshot JSON`. `agent_view` POST 가 form 바인딩 전 DB 값을 `old_values` 별도 캡처 (ModelForm.is_valid() instance mutation 회피) 후 변경된 필드만 audit row 생성 (변경 0이면 미생성). BO `/bo/agent/` 페이지 하단에 `Settings 변경 이력` 섹션 (최근 10건). |[2026-04-29-phase8-6-agent-extra-limits-audit.md](resources/documents/2026-04-29-phase8-6-agent-extra-limits-audit.md)|
 |2026.04.29| 0.4.0 Phase 9 — 안정화 및 배포 준비<br>로드맵 §3 의 본 Phase 8 의도 (안정화 + 배포 준비) 가 실제 개발에선 'agent 운영화' 로 재정의되어, 별 milestone Phase 9 로 분리해 처리. 자동 회귀 가드 — 라우팅 e2e (`test_routing_e2e.py` 9 cases) + 파이프라인 smoke (`test_pipeline_smoke.py` 9 cases, 노드 자체 mock + `_compiled_graph.cache_clear()` 계약) + prompt registry 정합 (`PromptRegistryConsistencyTests` 1 case). 12 대표 질문셋 + 기대 라우트 / 응답 / sources / TokenUsage purpose 분포 정리. `assets/prompts/chat/` 8 파일 사용처 점검 (미사용 0건). `CHANGELOG.md` 신규 — 0.3.x → 0.4.0 user-facing / operator-facing 변화. 배포 체크리스트 (마이그레이션 0001~0015 / 환경변수 / 빌드 / 데이터 backfill / 롤백 / 모니터링). |[2026-04-29-phase9-stabilization.md](resources/documents/2026-04-29-phase9-stabilization.md)|
 |2026.05.13| v0.5.0 Phase 9-1 — LLM Router + 인프라<br>`llm_router` prompt / purpose / tests 추가, `route_question(question, history)` 확장, `run_chat_completion(model=None)` 지원. DATE_CONDITION 우선순위와 `지급 일` 공백 변이, agent tool alias(`text` → `query`) 회귀 보강. |[2026-05-13-v0-5-0-phase9-1-llm-router.md](resources/documents/2026-05-13-v0-5-0-phase9-1-llm-router.md)|
+|2026.05.13| v0.5.0 Phase 9-2 — Validation + #76 Premise 보존<br>`query_rewriter.md` 에 가설/전제 보존 규칙 + example 추가, `QueryRewriterPremiseTests` (prompt content guard + rewrite cleanup guard) 신설. README §3/§7 4-tier 라우터 반영. S1~S7 / R1·R2 수동 QA 통과. |[2026-05-13-v0-5-0-phase9-2-validation-polish.md](resources/documents/2026-05-13-v0-5-0-phase9-2-validation-polish.md)|

--- a/assets/prompts/chat/query_rewriter.md
+++ b/assets/prompts/chat/query_rewriter.md
@@ -8,6 +8,8 @@ Rules:
 - Do NOT wrap the answer in quotes, do NOT prefix with labels like "검색어:", do NOT add explanations.
 - Do NOT invent facts that are not present in the conversation. Use only information that was explicitly mentioned.
 - Keep the rewrite tight — it is a search query, not a full sentence. Aim for the minimum keywords that uniquely identify the user's target topic.
+- Preserve premises and hypotheticals (e.g., "만약", "~라면", 숫자/기간 조건). Do NOT drop them — premises belong in the rewrite.
+- Preserve ordinal and ranking signals (e.g., "2번째", "두 번째", "n번째", "가장", "최대/최소", "비싼/싼", "높은/낮은"). Keep them in the rewrite — do NOT resolve them to a specific row or candidate (e.g., do NOT turn "2번째로 비싼거" into "부모 상"). Picking the actual row is the downstream retriever's / answer LLM's job; the rewrite must stay a self-contained search query.
 
 Examples
 
@@ -27,3 +29,15 @@ Conversation:
 user: 퇴직금 계산식 알려줘
 Current question: 퇴직금 계산식 알려줘
 Rewrite: NOOP
+
+Conversation:
+user: 퇴직금 계산식 알려줘
+assistant: (퇴직금 계산식 설명…)
+Current question: 만약 5년 근무하면?
+Rewrite: 5년 근무 시 퇴직금 계산
+
+Conversation:
+user: 경조사 규정 알려줘
+assistant: (경조사 전체 표 설명…)
+Current question: 2번째로 비싼거
+Rewrite: 경조사 중 두 번째로 비싼 항목

--- a/chat/services/prompt_builder.py
+++ b/chat/services/prompt_builder.py
@@ -13,7 +13,7 @@
 prompt_loader 가 프로세스 캐시를 담당하므로 함수마다 매번 디스크를 읽지 않는다.
 """
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from chat.services.prompt_loader import load_prompt
 from chat.services.qa_retriever import QAHit
@@ -25,6 +25,8 @@ def build_messages(
     chunk_hits: List[ChunkHit],
     qa_hits: List[QAHit],
     history: List[Dict[str, Any]],
+    *,
+    search_query: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """OpenAI 호환 messages 리스트를 만든다.
 
@@ -33,6 +35,10 @@ def build_messages(
         chunk_hits: DocumentChunk 검색 결과
         qa_hits: QAPair 검색 결과
         history: 세션 히스토리 [{'role': ..., 'content': ...}, ...]
+        search_query: query_rewriter 가 만든 self-contained 검색어. raw question
+            과 다를 때만 사용자 질문 섹션에 '대화 맥락 반영 질문' 으로 함께
+            렌더링한다. None / 빈 문자열 / question 과 동일하면 기존 출력
+            그대로 유지 (회귀 0).
 
     Returns:
         OpenAI API에 바로 넘길 수 있는 메시지 리스트
@@ -46,7 +52,9 @@ def build_messages(
     messages.extend(history)
 
     # ③ 이번 turn의 user 메시지: 자료 + 과거참고 + 질문
-    user_content = _render_user_content(question, chunk_hits, qa_hits)
+    user_content = _render_user_content(
+        question, chunk_hits, qa_hits, search_query=search_query,
+    )
     messages.append({'role': 'user', 'content': user_content})
 
     return messages
@@ -56,6 +64,8 @@ def _render_user_content(
     question: str,
     chunk_hits: List[ChunkHit],
     qa_hits: List[QAHit],
+    *,
+    search_query: Optional[str] = None,
 ) -> str:
     """현재 turn의 user 메시지 본문을 조립."""
     sections: List[str] = []
@@ -86,6 +96,14 @@ def _render_user_content(
 
     # 이번 질문
     sections.append('=== 사용자 질문 ===')
-    sections.append(question)
+    rewritten = (search_query or '').strip()
+    if rewritten and rewritten != question.strip():
+        # query_rewriter 가 후속 질문을 self-contained 검색어로 풀었다면,
+        # raw 원문은 UI/ChatLog 에 그대로 두되 LLM 에는 둘 다 보여 의도가
+        # 사라지지 않게 한다 (예: '비싼거' → '경조사 중 가장 비싼 항목').
+        sections.append(f'원문: {question}')
+        sections.append(f'대화 맥락 반영 질문: {rewritten}')
+    else:
+        sections.append(question)
 
     return '\n'.join(sections)

--- a/chat/services/single_shot/pipeline.py
+++ b/chat/services/single_shot/pipeline.py
@@ -67,8 +67,11 @@ def run_single_shot(
     if cached is not None:
         return cached
 
-    # 5) 프롬프트 조립
-    messages = build_single_shot_messages(question, chunk_hits, qa_hits, history)
+    # 5) 프롬프트 조립 — raw question 은 원문 그대로, rewriter 결과는 별도 신호로 전달.
+    #    builder 가 둘이 같으면 기존 출력 유지, 다르면 '대화 맥락 반영 질문' 으로 함께 렌더.
+    messages = build_single_shot_messages(
+        question, chunk_hits, qa_hits, history, search_query=search_query,
+    )
 
     # 6) OpenAI 호출
     reply, usage, model = run_chat_completion(messages)

--- a/chat/services/single_shot/prompting.py
+++ b/chat/services/single_shot/prompting.py
@@ -5,7 +5,7 @@
 확장 지점이 된다.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from chat.services.prompt_builder import build_messages
 from chat.services.qa_retriever import QAHit
@@ -17,6 +17,15 @@ def build_single_shot_messages(
     chunk_hits: List[ChunkHit],
     qa_hits: List[QAHit],
     history: List[Dict[str, Any]],
+    *,
+    search_query: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """OpenAI chat.completions 에 바로 넘길 messages 리스트를 돌려준다."""
-    return build_messages(question, chunk_hits, qa_hits, history)
+    """OpenAI chat.completions 에 바로 넘길 messages 리스트를 돌려준다.
+
+    `search_query` 는 `query_rewriter` 가 만든 self-contained 검색어. raw
+    `question` 과 다를 때만 user 메시지의 질문 섹션에 함께 렌더링되어 답변
+    LLM 이 후속 질문의 실제 의도를 보게 된다.
+    """
+    return build_messages(
+        question, chunk_hits, qa_hits, history, search_query=search_query,
+    )

--- a/chat/tests/test_prompt_builder.py
+++ b/chat/tests/test_prompt_builder.py
@@ -1,0 +1,82 @@
+"""prompt_builder.build_messages — search_query 분기 가드 (v0.5.0 Phase 9-2 / S1 fix).
+
+후속 질문 'A → 비싼거' 류는 `query_rewriter` 가 'A 중 가장 비싼 항목' 으로 풀어주지만,
+이전엔 그 결과가 retrieval 에만 쓰이고 답변 LLM 입력에는 raw '비싼거' 만 들어가서
+no-info 응답이 났다. 본 테스트는 builder 가 둘을 함께 노출하는지(다르면) /
+기존 출력을 유지하는지(같거나 빈 경우) 박제한다.
+"""
+
+from django.test import SimpleTestCase
+
+from chat.services.prompt_builder import build_messages
+
+
+class BuildMessagesSearchQueryTests(SimpleTestCase):
+    """`search_query` 가 raw question 과 다를 때만 추가 라인이 붙는다."""
+
+    def _last_user_content(self, messages):
+        # 마지막이 이번 turn 의 user 메시지.
+        self.assertEqual(messages[-1]['role'], 'user')
+        return messages[-1]['content']
+
+    def test_search_query_different_from_raw_appends_rewrite_line(self):
+        messages = build_messages(
+            '비싼거',
+            chunk_hits=[],
+            qa_hits=[],
+            history=[],
+            search_query='경조사 중 가장 비싼 항목',
+        )
+        body = self._last_user_content(messages)
+        self.assertIn('=== 사용자 질문 ===', body)
+        self.assertIn('원문: 비싼거', body)
+        self.assertIn('대화 맥락 반영 질문: 경조사 중 가장 비싼 항목', body)
+
+    def test_search_query_equal_to_raw_keeps_legacy_output(self):
+        messages = build_messages(
+            '퇴직금 계산식 알려줘',
+            chunk_hits=[],
+            qa_hits=[],
+            history=[],
+            search_query='퇴직금 계산식 알려줘',
+        )
+        body = self._last_user_content(messages)
+        self.assertIn('=== 사용자 질문 ===', body)
+        self.assertNotIn('대화 맥락 반영 질문', body)
+        self.assertNotIn('원문:', body)
+
+    def test_search_query_none_keeps_legacy_output(self):
+        messages = build_messages(
+            '경조사 규정 알려줘',
+            chunk_hits=[],
+            qa_hits=[],
+            history=[],
+        )
+        body = self._last_user_content(messages)
+        self.assertNotIn('대화 맥락 반영 질문', body)
+        self.assertNotIn('원문:', body)
+        # 질문은 한 줄로 그대로 들어간다.
+        self.assertIn('경조사 규정 알려줘', body)
+
+    def test_search_query_whitespace_only_treated_as_none(self):
+        messages = build_messages(
+            '경조사 규정 알려줘',
+            chunk_hits=[],
+            qa_hits=[],
+            history=[],
+            search_query='   ',
+        )
+        body = self._last_user_content(messages)
+        self.assertNotIn('대화 맥락 반영 질문', body)
+
+    def test_search_query_strips_before_compare(self):
+        # raw 와 search_query 가 양옆 공백만 다를 때도 '같음' 으로 본다.
+        messages = build_messages(
+            '퇴직금 계산식',
+            chunk_hits=[],
+            qa_hits=[],
+            history=[],
+            search_query='  퇴직금 계산식  ',
+        )
+        body = self._last_user_content(messages)
+        self.assertNotIn('대화 맥락 반영 질문', body)

--- a/chat/tests/test_query_rewriter.py
+++ b/chat/tests/test_query_rewriter.py
@@ -94,3 +94,85 @@ class QueryRewriterTests(TestCase):
                 history=history,
             )
         self.assertEqual(result, '연차 일수')
+
+
+class QueryRewriterPremiseTests(TestCase):
+    """v0.5.0 Phase 9-2 / #76 — 가설·전제 보존 가드.
+
+    (a) Prompt content guard: `assets/prompts/chat/query_rewriter.md` 가 premise
+        보존 규칙 + example 을 갖고 있는지 확인. silent regression 차단.
+    (b) Rewrite function guard: `_call_rewriter_llm` 을 mock 한 상태에서
+        `rewrite_query_with_history` 가 cleanup pipeline 으로 LLM 출력을 깎아먹지
+        않고 그대로 돌려주는지 확인. 실제 LLM 호출 금지.
+    """
+
+    def test_query_rewriter_prompt_contains_premise_rule(self):
+        from chat.services.prompt_loader import load_prompt
+
+        prompt_text = load_prompt('chat/query_rewriter.md')
+        # 규칙 라인 — 영문 키워드 + 한국어 트리거.
+        self.assertIn('Preserve premises', prompt_text)
+        self.assertIn('만약', prompt_text)
+        # Example 의 rewrite 라인.
+        self.assertIn('Rewrite: 5년 근무 시 퇴직금 계산', prompt_text)
+
+    def test_rewrite_query_with_history_returns_cleaned_llm_output(self):
+        history = [
+            {'role': 'user', 'content': '퇴직금 계산식 알려줘'},
+            {'role': 'assistant', 'content': '퇴직금 = 평균임금 × 30일 × 근속연수/365 ...'},
+        ]
+        # plan §4 계약: `_call_rewriter_llm` 을 call-site 에서 mock — 실제 LLM 호출 금지.
+        usage_stub = _stub_completion('5년 근무 시 퇴직금 계산')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('5년 근무 시 퇴직금 계산', usage_stub, 'gpt-mini'),
+        ) as mocked:
+            result, usage, model = query_rewriter.rewrite_query_with_history(
+                '만약 5년 근무하면?',
+                history=history,
+            )
+        mocked.assert_called_once()
+        # cleanup pipeline 이 premise 토큰을 깎아먹지 않는다.
+        self.assertEqual(result, '5년 근무 시 퇴직금 계산')
+        self.assertIs(usage, usage_stub)
+        self.assertEqual(model, 'gpt-mini')
+
+    # ------------------------------------------------------------------
+    # Phase 9-2 S1b — ordinal / ranking 보존 (#76 폴리시 추가분)
+    # ------------------------------------------------------------------
+
+    def test_query_rewriter_prompt_contains_ordinal_rule(self):
+        from chat.services.prompt_loader import load_prompt
+
+        prompt_text = load_prompt('chat/query_rewriter.md')
+        # 규칙 라인 — ordinal/ranking 키워드 + 부정 신호.
+        self.assertIn('Preserve ordinal and ranking signals', prompt_text)
+        self.assertIn('2번째', prompt_text)
+        self.assertIn('가장', prompt_text)
+        # rewriter 가 후보 행을 미리 확정하지 말라는 부정 지시.
+        self.assertIn('부모 상', prompt_text)
+        # Example.
+        self.assertIn('Current question: 2번째로 비싼거', prompt_text)
+        self.assertIn('Rewrite: 경조사 중 두 번째로 비싼 항목', prompt_text)
+
+    def test_rewrite_query_with_history_preserves_ordinal_in_cleanup(self):
+        history = [
+            {'role': 'user', 'content': '경조사 규정 알려줘'},
+            {'role': 'assistant', 'content': '본인 결혼 100만, 본인 상 500만, 배우자 상 100만, 부모 상 50만 ...'},
+        ]
+        usage_stub = _stub_completion('경조사 중 두 번째로 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=(
+                '경조사 중 두 번째로 비싼 항목', usage_stub, 'gpt-mini',
+            ),
+        ) as mocked:
+            result, usage, model = query_rewriter.rewrite_query_with_history(
+                '2번째로 비싼거',
+                history=history,
+            )
+        mocked.assert_called_once()
+        # cleanup pipeline 이 ordinal/ranking 토큰을 깎아먹지 않는다.
+        self.assertEqual(result, '경조사 중 두 번째로 비싼 항목')
+        self.assertIs(usage, usage_stub)
+        self.assertEqual(model, 'gpt-mini')

--- a/chat/tests/test_token_usage_purpose_call_sites.py
+++ b/chat/tests/test_token_usage_purpose_call_sites.py
@@ -102,6 +102,37 @@ class SingleShotPipelinePurposeTests(SimpleTestCase):
         self.assertEqual(purposes[0], tp.PURPOSE_QUERY_REWRITER)
         self.assertEqual(purposes[1], tp.PURPOSE_SINGLE_SHOT_ANSWER)
 
+    def test_rewriter_search_query_passed_to_prompt_builder(self):
+        """Phase 9-2 S1 fix — rewriter 결과 'rewritten' 이 build_single_shot_messages 에
+        keyword arg `search_query` 로 전달되어야 답변 LLM 이 후속 질문 의도를 본다."""
+        from chat.services.single_shot.pipeline import run_single_shot
+
+        with patch(
+            'chat.services.single_shot.pipeline.rewrite_query_with_history',
+            return_value=('rewritten', _UsageStub(), 'gpt-4o-mini'),
+        ), patch(
+            'chat.services.single_shot.pipeline.retrieve_documents', return_value=[],
+        ), patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa', return_value=[],
+        ), patch(
+            'chat.services.single_shot.pipeline.resolve_cache_hit', return_value=None,
+        ), patch(
+            'chat.services.single_shot.pipeline.build_single_shot_messages',
+            return_value=[{'role': 'user', 'content': 'q'}],
+        ) as builder_mock, patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+            return_value=('reply text', _UsageStub(), 'gpt-4o-mini'),
+        ), patch(
+            'chat.services.single_shot.pipeline.record_token_usage',
+        ):
+            run_single_shot('Q', history=[{'role': 'user', 'content': 'prev'}])
+
+        builder_mock.assert_called_once()
+        args, kwargs = builder_mock.call_args
+        # build_single_shot_messages(question, chunk_hits, qa_hits, history, *, search_query=...)
+        self.assertEqual(args[0], 'Q')
+        self.assertEqual(kwargs.get('search_query'), 'rewritten')
+
 
 # ---------------------------------------------------------------------------
 # workflow_node — rewriter (text-schema 게이트) + extractor

--- a/resources/documents/2026-05-13-v0-5-0-phase9-2-validation-polish.md
+++ b/resources/documents/2026-05-13-v0-5-0-phase9-2-validation-polish.md
@@ -1,0 +1,160 @@
+# 2026-05-13 개발 로그 — v0.5.0 Phase 9-2: Validation + Polish
+
+> **상위 플랜**: [`0.5.0_Phase_9-2_validation_polish_개발_플랜.md`](../plans/v_0_x/v_0_5_0/detail/0.5.0_Phase_9-2_validation_polish_개발_플랜.md)
+> **선행 Phase**: [v0.5.0 Phase 9-1](./2026-05-13-v0-5-0-phase9-1-llm-router.md) (LLM Router 인프라)
+> **Issue**: #76 (가설/전제 질문)
+> **Branch**: `feature/76-v0-5-0-polish` → `develop`
+
+---
+
+## 1. 요약
+
+- Phase 9-1 의 LLM Router 가 운영 의도대로 도는지 S1~S7 / R1·R2 수동 QA 시나리오 정리.
+- **#76 종결**: query rewriter 가 "만약 5년 근무하면?" 같은 후속 질문의 전제(`5년`/`근무`) 를 erase 하지 않도록 prompt 규칙 + example + deterministic 테스트 가드 추가.
+- README §3 (chat 앱), §7 (쿼리 파이프라인), §11 (개발 로그 표) 업데이트 — 4-tier 라우터 / `llm_router` / premise 보존 반영.
+- 라우팅·LLM Router·workflow 코드는 손대지 않음 (Phase scope 준수).
+
+---
+
+## 2. 변경 파일
+
+| 경로 | 변경 |
+|---|---|
+| `assets/prompts/chat/query_rewriter.md` | Rules 에 premise/hypothetical 보존 1줄 + Examples 에 `만약 5년 근무하면?` → `5년 근무 시 퇴직금 계산` 케이스 추가 |
+| `chat/tests/test_query_rewriter.py` | `QueryRewriterPremiseTests` 신규 클래스 + 2 케이스 (`test_query_rewriter_prompt_contains_premise_rule`, `test_rewrite_query_with_history_returns_cleaned_llm_output`). patch target 은 `chat.services.query_rewriter._call_rewriter_llm` (call-site). 실제 LLM 호출 없음 |
+| `README.md` | §3-1 chat 서비스 레이어에 `llm_router` 항목 추가 + `query_rewriter` 의 premise 보존 한 줄 보강. `question_router` 설명을 4-tier 로 갱신. §7 쿼리 파이프라인 앞에 라우팅 0 단계 추가. §11 개발 로그 표에 9-2 항목 추가 |
+| `resources/documents/2026-05-13-v0-5-0-phase9-2-validation-polish.md` | 본 dev log 신규 |
+| `resources/plans/v_0_x/v_0_5_0/detail/0.5.0_Phase_9-2_validation_polish_개발_플랜.md` | 본 Phase 세부 플랜 (Codex review 6 라운드 반영) |
+
+**의도적으로 변경하지 않음**:
+- `chat/services/question_router.py`, `chat/services/llm_router.py`, `chat/graph/nodes/*.py` — 라우팅 코드 동작 변경 금지 (Phase scope).
+- `assets/prompts/chat/llm_router.md` — LLM Router 시스템 프롬프트는 운영 데이터 관측 전 변경 금지 (over-tuning 회피, 플랜 §10 리스크 표 참조).
+
+---
+
+## 3. 자동 테스트 결과 (Docker canonical)
+
+> 명령: `docker compose exec -T web env OPENAI_API_KEY= python manage.py ...` — `OPENAI_API_KEY` 미설정 상태에서 오프라인 그린 확인 (call-site mock 동작 검증).
+
+| # | 명령 | 결과 |
+|---|---|---|
+| 1 | `python manage.py check` | ✅ System check 0 issues |
+| 2 | `test chat.tests.test_routing_e2e chat.tests.test_pipeline_smoke` | ✅ Ran 32 tests, OK |
+| 3 | `test chat.tests.test_llm_router chat.tests.test_token_purpose` | ✅ Ran 30 tests, OK |
+| 4 | `test chat.tests.test_query_rewriter` | ✅ Ran 7 tests, OK (기존 5 + 신규 `QueryRewriterPremiseTests` 2) |
+| 5 | `test bo` | ✅ Ran 30 tests, OK (staticfiles UserWarning 무관, 정적 디렉토리 미수집 안내) |
+| 6 | `test chat.tests.test_query_rewriter.QueryRewriterPremiseTests` (단독) | ✅ Ran 2 tests, OK |
+
+> 모든 명령은 `--noinput --keepdb` 옵션과 함께 실행. (CI 와 동일하게 깨끗한 DB 가 필요하면 `--keepdb` 제거 후 `--noinput` 만 사용 — 기존 test DB 가 있으면 prompt 가 뜨므로 `--noinput` 만으로는 EOFError 가 난다. 본 실행은 로컬 `--keepdb` 로 시간 절약.)
+
+---
+
+## 4. 수동 QA 시나리오 (사용자 진행 완료 — 이상 없음)
+
+> 사용자 브라우저 수동 QA 완료. 전 시나리오 통과 확인. §4-1 / §4-2 fix 적용 후 S1 / S1b 도 재검증 통과.
+>
+> 진입점: 루트 `/` (`AI_Chat/urls.py` 가 `path('', include('chat.urls'))`; 로컬 dev 는 `http://localhost:8001/`). BO dashboard 는 `/bo/`.
+
+| # | 시나리오 | 기대 / 합격선 | 결과 |
+|---|---|---|---|
+| S1 | "경조사" → "비싼거" | rewriter 가 `경조사 중 가장 비싼 항목` 으로 치환, single_shot 응답 정상 | ✅ §4-1 fix 후 재검증 통과 — `본인 상 500만원` 정상 응답 |
+| S1b | "경조사" → "2번째로 비싼거" | rewriter 가 `경조사 중 두 번째로 비싼 항목` 처럼 ordinal 보존, 표의 두 번째 행 응답 | ✅ §4-2 prompt+test 가드 후 재검증 통과 — `배우자 상 100만원` 정상 응답 |
+| S2 | "경조사" → "이거 말고 더 있을건데?" | 메타-요청 인식 | ✅ 사용자 수동 QA 통과 |
+| S3 | "본인 결혼?" → "자녀는?" | rewriter `자녀 결혼 경조금` 으로 치환 | ✅ 사용자 수동 QA 통과 |
+| S4 | "퇴직금 계산식?" 단발 | rewriter NOOP, 정상 응답 | ✅ 사용자 수동 QA 통과 |
+| S5 | 첫 질문 (history=[]) — 예: `회사 규정에서 반려동물 동반 가능 여부는?` (fallback: `사내 도서 구매 지원 기준은?`) | rewriter skip → Tier 3 LLM Router 진입 → BO dashboard `LLM 라우터` 카운트 +1 | ✅ 사용자 수동 QA 통과 |
+| S6 | "퇴직금 비교 vs 계산 vs 정의" | reason `llm:...` 가 매번 잡힘 | ✅ 사용자 수동 QA 통과 |
+| **S7** | **2-turn**: turn1 `퇴직금 계산식 알려줘` → turn2 `만약 5년 근무하면?` | route `agent` + premise 토큰 보존 | ✅ 사용자 수동 QA 통과 |
+| R1 | "급여 지급일은?" | route `agent`, reason `date_condition_keyword`. dashboard `LLM 라우터` 카운트 불변 | ✅ 사용자 수동 QA 통과 |
+| R2 | shell 임시 RouterRule `(pattern='지급일', route='workflow')` 등록 → `route_question` 호출 → `.delete()` | `route='workflow'`, `reason.startswith('db_rule:')` + cleanup 완료 | ✅ 사용자 수동 QA 통과 |
+
+---
+
+## 4-1. S1 수동 QA 실패 및 fix (#76 폴리시 추가분)
+
+**증상**: turn1 `경조사` 정상 → turn2 `비싼거` 답변이 `회사 자료에 해당 정보가 없습니다.` 로 실패.
+
+**원인**: `chat/services/single_shot/pipeline.py:run_single_shot()` 이 `query_rewriter` 결과 `search_query` 를 `retrieve_documents` / `find_canonical_qa` 입력에만 쓰고, 최종 `build_single_shot_messages(question, ...)` 에는 raw `비싼거` 만 넘김 → 답변 LLM 이 후속 질문 의도(`경조사 중 가장 비싼 항목`) 를 못 보고 no-info 분기로 빠짐.
+
+**fix** (원본 질문은 UI / ChatLog 에 그대로 보존):
+
+| 파일 | 변경 |
+|---|---|
+| `chat/services/prompt_builder.py` | `build_messages(..., *, search_query=None)` + `_render_user_content(..., *, search_query=None)`. `search_query.strip()` 가 비어있지 않고 raw question 과 다를 때만 `=== 사용자 질문 ===` 아래에 `원문: ...` + `대화 맥락 반영 질문: ...` 두 줄 렌더. 같거나 None 이면 기존 출력 동일 (회귀 0) |
+| `chat/services/single_shot/prompting.py` | `build_single_shot_messages(..., *, search_query=None)` 시그니처 확장 → `build_messages` 로 forward |
+| `chat/services/single_shot/pipeline.py` | `build_single_shot_messages(question, chunk_hits, qa_hits, history, search_query=search_query)` 로 호출. rewriter 가 NOOP/실패면 `search_query == question` 이라 builder 가 기존 출력 유지 |
+| `chat/tests/test_prompt_builder.py` (신규) | 5 케이스: rewrite 다를 때 라인 추가 / 동일 시 누락 / None 시 누락 / whitespace-only 시 누락 / strip 비교 |
+| `chat/tests/test_token_usage_purpose_call_sites.py` | `test_rewriter_search_query_passed_to_prompt_builder` 1 케이스 추가 — pipeline 이 `search_query='rewritten'` 을 builder 에 keyword 로 전달함을 단언 |
+
+**계약**: rewriter 가 빈 history / NOOP / 예외 fallback 으로 raw 와 같은 문자열을 돌려주면 builder 의 분기가 자연 드롭 → 기존 동작과 byte-identical. 비교는 `strip()` 후 정확 일치만 본다 (대소문자/조사 변형은 분기 발동).
+
+---
+
+## 4-2. S1b 수동 QA 실패 및 fix — ordinal/ranking 보존
+
+**증상**: turn1 `경조사` (표 정상) → turn2 `2번째로 비싼거` 응답이 `부모 상 50만원` (오답). 표 기준 정답은 `배우자 상 100만원`.
+
+**원인 (로그)**: `chat.services.query_rewriter` INFO 로그 `쿼리 재작성: '2번째로 비싼거' → '부모 상 경조사 지원금'`. 즉 rewriter 가 ordinal 신호(`2번째`, `비싼`) 를 erase 하고 후보 행(`부모 상`) 으로 임의 확정 → retrieval 이 `부모 상` 청크만 잡고 답변 LLM 도 그대로 응답. §4-1 의 search_query 전달 fix 와 별개의 rewriter prompt 버그.
+
+**fix (prompt + test 가드, 코드 동작 변경 없음)**:
+
+| 파일 | 변경 |
+|---|---|
+| `assets/prompts/chat/query_rewriter.md` | Rules 에 ordinal/ranking 보존 규칙 1줄 추가 — `2번째 / 두 번째 / n번째 / 가장 / 최대·최소 / 비싼·싼 / 높은·낮은` 보존 + 후보 행 임의 확정 금지(`"부모 상"` 예시로 명시). Examples 에 `2번째로 비싼거` → `경조사 중 두 번째로 비싼 항목` 케이스 추가 |
+| `chat/tests/test_query_rewriter.py` | `QueryRewriterPremiseTests` 에 2 케이스 추가 — (a) `test_query_rewriter_prompt_contains_ordinal_rule` (prompt content guard: 규칙 문구 + 부정 신호 `부모 상` + example 라인), (b) `test_rewrite_query_with_history_preserves_ordinal_in_cleanup` (cleanup 회귀 guard: `_call_rewriter_llm` mock 결과를 깎아먹지 않음) |
+
+**계약**: 코드 동작은 변경 없음. ordinal 보존은 LLM 의 prompt 준수에 의존하며, prompt 파일이 silent 하게 회귀하면 (a) 가, cleanup pipeline 이 ranking 토큰을 깎아먹으면 (b) 가 차단한다. 사용자 manual S1b 재검증 통과 — 표의 두 번째 행 `배우자 상 100만원` 정상 응답.
+
+---
+
+## 5. 미해결 리스크
+
+수동 QA 대기 리스크는 해소 (사용자 전 시나리오 통과 확인). 잔존 리스크는 일반 운영 리스크 한정:
+
+| 리스크 | 상태 |
+|---|---|
+| LLM Router / rewriter prompt 가 운영 중 새 패턴에 약하게 반응 | observed-only dashboard (`LLM 라우터` purpose) 로 운영 데이터 누적 관측. 새 prompt 튜닝은 v0.5.x 후속 작업, 본 Phase 종결 시점에는 변경 금지 |
+| prompt content guard 의 한계 | (a) prompt 파일이 silent 하게 회귀하면 `QueryRewriterPremiseTests` 가 차단. (b) cleanup pipeline 회귀는 `_call_rewriter_llm` mock guard 로 별도 차단. 단 실제 LLM 의 prompt 추종은 자동으로 보지 못함 — manual 회귀가 발견되면 후속 Phase 에서 케이스 추가 |
+
+---
+
+## 6. 부록 — 실 검증 실행 출력
+
+```
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py check
+System check identified no issues (0 silenced).
+
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb chat.tests.test_routing_e2e chat.tests.test_pipeline_smoke
+Using existing test database for alias 'default'...
+... router INFO 로그 다수 ...
+----------------------------------------------------------------------
+Ran 32 tests in 0.251s
+OK
+
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb chat.tests.test_llm_router chat.tests.test_token_purpose
+... validate_purpose WARNING 2건 (의도된 음성 케이스) ...
+----------------------------------------------------------------------
+Ran 30 tests in 0.042s
+OK
+
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb chat.tests.test_query_rewriter
+INFO chat.services.query_rewriter: 쿼리 재작성: '몇 일?' → '연차 일수'
+INFO chat.services.query_rewriter: 쿼리 재작성: '만약 5년 근무하면?' → '5년 근무 시 퇴직금 계산'
+----------------------------------------------------------------------
+Ran 7 tests in 0.019s
+OK
+
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb bo
+... staticfiles UserWarning (정적 미수집 안내, 무관) ...
+----------------------------------------------------------------------
+Ran 30 tests in 0.344s
+OK
+
+$ docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb chat.tests.test_query_rewriter.QueryRewriterPremiseTests
+INFO chat.services.query_rewriter: 쿼리 재작성: '만약 5년 근무하면?' → '5년 근무 시 퇴직금 계산'
+----------------------------------------------------------------------
+Ran 2 tests in 0.004s
+OK
+```
+
+> §4 의 `chat.services.query_rewriter` 로그 `쿼리 재작성: '만약 5년 근무하면?' → '5년 근무 시 퇴직금 계산'` 출현 = §3 표의 자동 가드가 cleanup pipeline 으로 premise 토큰을 깎아먹지 않음을 실증.

--- a/resources/plans/v_0_x/v_0_5_0/detail/0.5.0_Phase_9-2_validation_polish_개발_플랜.md
+++ b/resources/plans/v_0_x/v_0_5_0/detail/0.5.0_Phase_9-2_validation_polish_개발_플랜.md
@@ -1,0 +1,218 @@
+# v0.5.0 — Phase 9-2 상세 개발 플랜: Validation + Polish
+
+> **상위 플랜**: [`feat_v0_5_0_plan.md`](../feat_v0_5_0_plan.md)
+> **선행 Phase**: [`0.5.0_Phase_9-1_llm_router_infra_개발_플랜.md`](./0.5.0_Phase_9-1_llm_router_infra_개발_플랜.md) (머지 완료, commit `26c2883`)
+> **Issue**: #76 (가설/전제 질문)
+> **Branch**: `feature/76-v0-5-0-polish` (현 브랜치)
+> **Base / Target**: `develop`
+> **Phase 9-2 본질**: **검증 + #76 종결**. Phase 9-1 인프라가 운영 의도대로 도는지 S1~S7 시나리오로 확인하고, **#76 가설/전제 보존**은 본 Phase 의 핵심 deliverable 이므로 prompt 1줄 + example + deterministic 테스트를 **원칙적으로 수행**한다 (S7 결과와 무관).
+
+---
+
+## 1. 목적 (Why)
+
+Phase 9-1 의 LLM Router 가 들어왔으니 S1~S7 시나리오(특히 **S2 메타-요청** / **S7/#76 가설**) 가 실제로 의도대로 라우팅·응답되는지 확인한다. 본 Phase 는 검증 + **#76 종결**이 핵심이며, query rewriter 가 전제(`만약 5년 근무하면`) 를 erase 해 retrieval 이 깨지는 회귀를 막기 위해 **prompt 규칙 1줄 + example + deterministic 테스트**를 원칙적으로 추가한다 (S7 manual 결과와 무관).
+
+---
+
+## 2. 작업 구분
+
+| 트랙 | 성격 | 산출물 |
+|---|---|---|
+| A. Validation | 코드 변경 없음 | 수동 QA 표, 검증 명령 결과, dashboard 캡처 |
+| B. 회귀 가드 | 테스트만 추가 | `test_query_rewriter`/`test_routing_e2e` 보강 |
+| C. **#76 premise 보존** | prompt + deterministic 테스트 | `assets/prompts/chat/query_rewriter.md` 1줄 + example + 자동 테스트 2건 |
+| D. 문서 polish | 코드 변경 없음 | README §3/§7/§11, dev log |
+
+> **A/B/C/D 모두 무조건 수행.** C 는 #76 종결을 위해 필수 — S7 manual 결과와 무관하게 prompt + test 가드를 남긴다. S7 의 브라우저 결과는 dev log 에 기록만 한다.
+
+---
+
+## 3. Validation — S1~S7
+
+> 모든 시나리오는 브라우저(루트 `/` — `AI_Chat/urls.py` 가 `path('', include('chat.urls'))`. 로컬 dev 는 `http://localhost:8001/`) + 서버 로그 (`router_node.logger.info('라우팅: ...')`) + BO dashboard 의 `LLM 라우터` purpose 카운트 3 축으로 본다. `single_shot` 분기는 router 로그 미생성이라 Django shell 의 `route_question(q, history)` 직접 호출로 `RouteDecision.reason` 확인.
+
+| # | 시나리오 | 기대 route / reason | 점검 포인트 |
+|---|---|---|---|
+| S1 | "경조사" → "비싼거" | single_shot, reason `llm:...` 또는 `default` | rewriter 가 `경조사 중 가장 비싼 항목` 으로 치환 |
+| S2 | "경조사" → "이거 말고 더 있을건데?" | agent 또는 single_shot, reason `llm:...` | 메타-요청 인식해 "보여드린 게 전부입니다" 류 응답 |
+| S3 | "본인 결혼?" → "자녀는?" | single_shot, rewriter 가 `자녀 결혼 경조금` 으로 치환 | retrieval 이 자녀 결혼 chunk 잡음 |
+| S4 | "퇴직금 계산식?" 단발 | workflow (DB rule) 또는 single_shot | rewriter NOOP |
+| S5 | 첫 질문 (history=[]) — **목적은 답변 품질 검증이 아니라** `history=[]` 에서 rewriter skip + Tier 3 LLM Router 진입 (dashboard `LLM 라우터` purpose 카운트 +1) 확인. **1차 예시** `"회사 규정에서 반려동물 동반 가능 여부는?"`. **Fallback 예시** (1차가 운영 DB rule 에 잡힐 때): `"사내 도서 구매 지원 기준은?"`. ⚠️ `"복리후생 규정에서 본인 결혼 경조금은?"` 는 기존 fixture 패턴(`pattern='복리후생 규정에서'`) 과 동형이라 운영 DB 에 유사 rule 이 있으면 Tier 1 DB rule 로 잡혀 검증 실패 → **사용 금지**. DATE_CONDITION/WORKFLOW/AGENT 키워드 미포함 + 흔한 DB rule pattern 미포함 문장만 채택 | rewriter skip → Tier 1/2 miss → Tier 3 LLM Router 진입 → LLM 분류 결과대로 라우팅 | dashboard `LLM 라우터` +1 (observed-only 정책 유지 — 검증 실행 전 0건이면 행 없음이 정상이므로 본 시나리오 실행으로 행 생성 확인). 답변 본문 품질은 합격 기준 아님 |
+| S6 | "퇴직금 비교 vs 계산 vs 정의" | reason `llm:...` 가 매번 잡힘 | LLM 분기 정상 |
+| **S7** | **2-turn** 시나리오 (rewriter 가 실제로 돌도록): turn1 user `"퇴직금 계산식 알려줘"` → assistant 응답 → turn2 user `"만약 5년 근무하면?"` | turn2 라우팅 PASS 조건: route `agent` + 다음 중 하나의 reason — (a) `llm:...` (LLM 이 가설로 `agent` 분류), (b) `agent_keyword` (`만약` 매치한 Tier 4 fallback — **단 LLM 이 예외/None/미가용으로 실패해 Tier 3 가 fall-through 한 경우에만** 도달 가능). **FAIL 조건 (좁힘)**: LLM 이 정상 응답으로 `single_shot` 또는 `workflow` 를 반환한 경우 — `route_question` 은 그 결과를 즉시 사용하고 Tier 4 키워드 fallback 으로 내려가지 않으므로(`question_router.py:196-201`), `만약` 이 들어가도 키워드 fallback 으로 살아나지 않는다 + rewriter 출력에 `5년` / `근무` / `퇴직금` 토큰 모두 보존 | (1) router 로그 `reason=` 값 기록 (2) **`chat.services.query_rewriter` 로거의 `INFO` 라인** `쿼리 재작성: %r → %r` (`chat/services/query_rewriter.py:83`) 에서 right-hand cleaned 출력에 `5년`·`근무`·`퇴직금` 3 토큰 보존 필수. (agent_node 자체는 effective_question 을 로깅하지 않으므로 query_rewriter 로그를 기준으로 한다 — agent_node 에 별도 로그 추가는 본 Phase scope 밖.) agent_node 가 `history` 가 비어있지 않을 때만 rewriter 호출(`chat/graph/nodes/agent.py:61-64`) 이므로 **단발 질문으로 S7 검증 금지** |
+| R1 | "급여 지급일은?" (회귀) | agent, reason `date_condition_keyword` | LLM 호출 0 — dashboard `LLM 라우터` 불변 |
+| R2 | **임시 DB rule 등록 후 cleanup 의무**: Django shell 에서 `RouterRule.objects.create(name='_tmp_phase92_r2', route='workflow', match_type='contains', pattern='지급일', priority=100, enabled=True, workflow_key='')` 만든 뒤 `route_question('급여 지급일은?', [])` 결과만 확인 → 즉시 `.delete()` | `RouteDecision.route == 'workflow'`, `reason.startswith('db_rule:')` — route override 만 검증, workflow 실제 실행은 검증 범위 밖 | **cleanup 의무 명시**: broad `pattern='지급일'` rule 을 운영에 남기면 이후 R1/실사용 쿼리를 오염시킨다. shell 종료 전 반드시 `.delete()`. 워크플로 실행까지 보고 싶으면 별도로 `workflow_key='date_calculation'` 지정 + cleanup, 그리고 본 행과 분리해 기록 |
+
+**합격선**: S1~S6 / R1 / R2 모두 기대대로 동작. S7 는 (i) route 가 `agent`, (ii) reason 이 `llm:...` 이거나 (LLM 이 예외/None/미가용일 때 한해) `agent_keyword`, (iii) premise 토큰 보존 — 세 조건 모두 충족. **LLM 이 정상 응답으로 `single_shot`/`workflow` 를 돌려준 경우 (i) 위반으로 S7 FAIL** — 키워드 fallback 으로 구제되지 않는다.
+
+---
+
+## 4. #76 premise 보존 (필수 — 본 Phase 의 핵심 deliverable)
+
+**리스크**: `query_rewriter.md` 가 "Keep the rewrite tight — minimum keywords" 만 강조 → `만약 5년 근무하면?` 같은 후속 질문이 `퇴직금 계산식` 으로 압축되어 `5년` 전제가 사라지면 retrieval 이 일반 정의 청크만 잡고 agent 의 계산 단서가 끊긴다. (라우팅 자체는 router_node 가 rewriter 이전에 동작하므로 LLM Router 분류는 영향 없음 — 영향 범위는 retrieval 입력만.) #76 종결을 위해 **회귀 가드가 무조건 남아야** 하므로 본 트랙은 S7 manual 결과와 무관하게 수행한다.
+
+**Contract (무조건 수행)**:
+
+1. **Prompt 수정** — `assets/prompts/chat/query_rewriter.md`
+   - Rules 절에 1줄 추가:
+     - `- Preserve premises and hypotheticals (e.g., "만약", "~라면", 숫자/기간 조건). Do NOT drop them — premises belong in the rewrite.`
+   - Examples 에 1 케이스 추가:
+     ```
+     Conversation:
+     user: 퇴직금 계산식 알려줘
+     Current question: 만약 5년 근무하면?
+     Rewrite: 5년 근무 시 퇴직금 계산
+     ```
+
+2. **테스트** (`chat/tests/test_query_rewriter.py`) — 신규 클래스 `QueryRewriterPremiseTests` 안에 케이스 2건 분리. 실제 LLM 호출 금지.
+
+   (a) **Prompt content guard** — `QueryRewriterPremiseTests.test_query_rewriter_prompt_contains_premise_rule`
+   - `chat.services.prompt_loader.load_prompt('chat/query_rewriter.md')` (또는 파일 직접 read) 결과 문자열에:
+     - `Preserve premises` 와 `만약` 두 토큰이 모두 등장하는지 단언.
+     - Example 의 `Rewrite: 5년 근무 시 퇴직금 계산` 라인이 포함되는지 단언.
+   - 목적: prompt 파일이 silent 하게 회귀(규칙/예시 삭제) 되는 걸 차단. prompt 변경만으로 가드가 동작하므로 LLM 호출 불필요.
+
+   (b) **Rewrite function guard** — `QueryRewriterPremiseTests.test_rewrite_query_with_history_returns_cleaned_llm_output`
+   - **patch target (call-site)**: `chat.services.query_rewriter._call_rewriter_llm` 을
+     `return_value=('5년 근무 시 퇴직금 계산', _fake_usage(), 'gpt-mini')` 으로 mock.
+   - history 는 turn1 `user: 퇴직금 계산식 알려줘` / `assistant: ...` 두 메시지.
+   - 호출: `rewrite_query_with_history('만약 5년 근무하면?', history)`.
+   - 단언:
+     - 반환 search_query 가 `'5년 근무 시 퇴직금 계산'` 와 정확히 일치 (cleanup pipeline 이 mock 출력을 깎아먹지 않는지).
+     - usage / model 이 그대로 전달됨.
+   - 한계 자인: 이 테스트는 cleanup 회귀만 막고, LLM 이 실제로 premise 를 보존하는지는 보지 않는다. 그쪽 가드는 (a) 의 prompt content + manual S7 가 담당.
+
+3. **Commit 분리**: C 트랙은 별도 커밋 (`fix(#76): preserve hypothetical premise in query rewriter prompt` + test). A/B/D 와 분리해 PR diff 가독성 확보.
+
+4. **회귀 재확인**: C 트랙 적용 후 §3 의 S1/S3/S4 (NOOP 또는 기존 rewrite 동작) 를 manual 로 재실행해 새 prompt 규칙이 다른 케이스에 부작용 없는지 확인.
+
+---
+
+## 5. 회귀 가드 — 항상 추가
+
+> Phase 9-1 가 박은 회귀 계약은 그대로 유지. 본 Phase 는 추가 가드만.
+
+1. **rewriter NOOP 회귀**: 기존 `chat.tests.test_query_rewriter.QueryRewriterTests.test_noop_sentinel_keeps_original_question` 가 NOOP sentinel 동작을 이미 가드하고 있다 — **재확인만** 하고 신규 테스트는 만들지 않는다. 동등한 동작 단언이 누락된 경우에 한해서만 보강(중복 테스트 생성 금지). 표기는 Django dotted label 로 통일 — `::` 같은 pytest 스타일 금지.
+2. **routing offline mock 합격선 재확인**: 새 케이스 추가 없이도, §8 Docker canonical 명령 (`docker compose exec -T web env OPENAI_API_KEY= python manage.py test chat.tests.test_routing_e2e chat.tests.test_pipeline_smoke`) 결과가 green 인지 PR 본문에 첨부.
+3. **DATE_CONDITION 회귀 단언 유지**: §3 R1 시나리오는 manual; 자동 가드는 Phase 9-1 의 `test_date_condition_keyword_skips_llm_call` 시리즈가 담당 — 본 Phase 에서 추가 가드 불필요.
+
+---
+
+## 6. Mock target / cache 계약 (재확인, 변경 금지)
+
+| 항목 | 계약 |
+|---|---|
+| 라우팅 단위/통합 테스트 LLM mock | `chat.services.question_router._llm_classify` (call-site binding). `chat.services.llm_router._llm_classify` 가 아님 |
+| `_llm_classify` 단위 테스트의 OpenAI/usage mock | `chat.services.llm_router.run_chat_completion` + `chat.services.llm_router.record_token_usage` (call-site) |
+| graph 노드 stub patch 시 | `_compiled_graph.cache_clear()` setUp 첫 줄/마지막 줄 + `addCleanup`. 변경 금지 |
+| LLM 출력 `workflow_key` | 항상 무시 — `RouteDecision.workflow_key=''` 강제. 변경 금지 |
+| DATE_CONDITION_KEYWORDS | Tier 2, LLM 보다 먼저. 변경 금지 |
+| Dashboard `_PURPOSE_LABELS` | observed-only — 0건 purpose 는 행으로 강제 노출하지 않는다. 변경 금지 |
+
+---
+
+## 7. 문서 polish
+
+1. **README**
+   - §3 `chat` 절: `chat/services/llm_router.py` 한 줄 추가, 라우터 4-tier 요약.
+   - §7 쿼리 파이프라인: 1단계 앞에 `0. 라우팅 (DB rule → DATE_CONDITION → LLM Router → 키워드 fallback)` 한 줄 추가.
+   - §11 개발 로그 표: `2026-05-13-v0-5-0-phase9-1-llm-router.md` 가 이미 등록되어 있다면, 9-2 dev log 도 같은 표에 한 줄 추가.
+2. **Dev log** — `resources/documents/YYYY-MM-DD-v0-5-0-phase9-2-validation-polish.md` 신규
+   - 요약: S1~S7 + R1/R2 결과 표 + (수행 시) #76 premise 보존 변경 내역 + dashboard 캡처 1장.
+3. **사용자 manual QA 시나리오** — README 또는 `resources/documents/` 어디든 별도 파일은 만들지 않는다. 본 Phase 의 dev log 안에 §3 표 그대로 인용.
+
+---
+
+## 8. 검증 명령 (focused)
+
+> **Canonical 실행 환경 = Docker**. 본 저장소 문서들은 `docker compose exec -T web python manage.py ...` 를 기준 명령으로 쓴다. 로컬 셸에 `python` 이 없거나 venv 가 따로 잡혀 있어 그대로 실행하면 깨지므로, 본 Phase 의 검증 명령도 Docker 를 1차 기준으로 한다.
+>
+> **로컬 보조**: activated venv 환경이거나 `.venv/bin/python manage.py ...` 처럼 절대 경로로 호출 가능한 경우에 한해 동일 라벨로 대체 실행 가능. 단 결과는 Docker 환경 그린이 합격선.
+
+```bash
+# 1. 회귀 — 오프라인 그린 확인 (Docker, canonical)
+docker compose exec -T web env OPENAI_API_KEY= python manage.py check
+docker compose exec -T web env OPENAI_API_KEY= python manage.py test \
+    chat.tests.test_routing_e2e chat.tests.test_pipeline_smoke
+docker compose exec -T web env OPENAI_API_KEY= python manage.py test \
+    chat.tests.test_llm_router chat.tests.test_token_purpose
+docker compose exec -T web env OPENAI_API_KEY= python manage.py test \
+    chat.tests.test_query_rewriter
+docker compose exec -T web env OPENAI_API_KEY= python manage.py test bo
+
+# 2. C 트랙: premise 보존 가드 (prompt content + rewrite function)
+docker compose exec -T web env OPENAI_API_KEY= python manage.py test \
+    chat.tests.test_query_rewriter.QueryRewriterPremiseTests
+```
+
+> **참고**: Django `manage.py test` 는 pytest 의 `-k` 옵션을 지원하지 않는다. 단독 실행은 위처럼 **정확한 dotted test label** (`<app>.tests.<module>.<TestCase>[.<method>]`) 로 지정한다.
+
+수동 검증 — 브라우저 + Django shell + `/bo/` dashboard 3 축으로 §3 표 각 행.
+
+---
+
+## 9. Definition of Done
+
+1. §3 표의 S1~S6 / R1 / R2 모두 기대대로 동작 — dev log 결과 표에 행마다 ✅ 표기. R2 의 임시 RouterRule 은 cleanup 완료(`.delete()`) 확인.
+2. S7 (2-turn 시나리오) 결과 dev log 기록:
+   - route 는 `agent`. reason 은 `llm:...` PASS, `agent_keyword` 는 **LLM 이 예외/None/미가용으로 Tier 3 fall-through 한 경우에만** PASS.
+   - **FAIL 조건**: LLM 이 정상 응답으로 `single_shot` / `workflow` 를 반환한 경우 — `route_question` 은 그 결과를 즉시 사용하고 Tier 4 키워드 fallback 으로 내려가지 않으므로 `만약` 키워드로 구제되지 않는다.
+   - `chat.services.query_rewriter` 의 `INFO` 로그 `쿼리 재작성: %r → %r` 우측 cleaned 값에 `5년` / `근무` / `퇴직금` 3 토큰 보존.
+   - green/red 무관 §4 prompt + 테스트 가드는 항상 머지된다.
+3. **§4 C 트랙 산출물 무조건 머지**: prompt 1줄 + example + 자동 테스트 2건 (`test_query_rewriter_prompt_contains_premise_rule`, `test_rewrite_query_with_history_returns_cleaned_llm_output`) 모두 그린.
+4. §8 의 회귀 명령 6 종 전 그린 (Docker canonical 기준). C 트랙 테스트는 `chat.tests.test_query_rewriter.QueryRewriterPremiseTests` 라벨로도 단독 그린.
+5. BO dashboard 의 `LLM 라우터` purpose 라벨 노출 확인 + 카운트 변화 캡처 (**조건부**):
+   - **S5**: LLM Router 진입 확인이 목적이므로 카운트 **+1 기대** — 미증가는 FAIL.
+   - **S7**: reason 이 `llm:...` 이면 카운트 **+1 기대**. reason 이 `agent_keyword` fallback (LLM 예외/None/미가용으로 Tier 3 fall-through) 이면 `PURPOSE_LLM_ROUTER` 기록이 없을 수 있으므로 **카운트 증가 없음도 정상** — 단, dev log 에 fallback 사유(예외 메시지 / API key 미설정 등) 를 함께 기록.
+   - observed-only 정책상, 본 Phase 검증 실행 전 0건이면 행 없음이 정상 — S5 실행 후 행 생성 확인이 합격선.
+6. README §3/§7/§11 + dev log 작성.
+7. **변경 금지 계약 유지**: §6 의 6개 항목, Phase 9-1 의 `RouteDecision` 비참조 계약, observed-only 정책.
+
+---
+
+## 10. 리스크
+
+| 리스크 | 대응 |
+|---|---|
+| Query rewriter 가 `만약/N년` 전제를 erase → S7 retrieval 빈약 | §4 prompt 1줄 + example + deterministic 테스트 2건 (prompt content guard + rewrite function guard) 무조건 추가. 영향 범위는 retrieval 만 (LLM Router 분류는 영향 없음) |
+| S7 을 단발 질문으로 검증해 rewriter 가 아예 안 도는 false-pass | §3 S7 행에 명시: agent_node 는 `state.history` 가 비어있지 않을 때만 `rewrite_query_with_history` 호출 (`chat/graph/nodes/agent.py:61-64`). S7 은 **반드시 2-turn** — 단발 질문 검증 금지 |
+| R2 의 broad `pattern='지급일'` rule 이 운영/이후 검증을 오염 | §3 R2 행에 cleanup 의무 명시. Django shell 에서 등록·확인·`.delete()` 전부 한 세션 안에서. workflow 실행 검증은 별도 행으로 분리 |
+| LLM Router 가 가설 질문을 `single_shot`/`workflow` 로 정상 응답하며 오분류 (S7 FAIL 경로) | **Phase 9-2 DoD 미충족 / 블로커**로 간주. Claude 가 임의로 `assets/prompts/chat/llm_router.md` 를 수정하지 말고 **검증 중단**, 사용자/Codex 에 scope 재승인 요청 (운영 데이터 관측 vs prompt 튜닝 분기 결정). ⚠️ 여기서 변경 금지인 prompt 는 **`assets/prompts/chat/llm_router.md`** (LLM Router 시스템 프롬프트) 한정 — §4 의 **`assets/prompts/chat/query_rewriter.md` premise 보존 prompt 변경은 본 Phase 의 필수 deliverable 이므로 계속 수행**, 둘은 서로 다른 작업 |
+| DATE_CONDITION 가 LLM 우회 — 회귀 0 깨질 위험 | Phase 9-1 의 `test_date_condition_keyword_skips_llm_call` 시리즈가 박제. 본 Phase 추가 가드 불필요 |
+| 테스트가 `chat.services.llm_router._llm_classify` 를 mock → 그린 위장 | §6 계약 위반. 신규 mock 추가 시 반드시 call-site binding (`chat.services.question_router._llm_classify`) |
+| Dashboard 에 `llm_router` 가 0건일 때 zero-fill 로 강제 노출하려는 유혹 | observed-only 정책 유지. 0건이면 행 없음이 정상 |
+| Premise prompt 수정이 다른 시나리오(S1/S3 NOOP) 회귀 | §4 적용 시 §3 의 S1/S3/S4 까지 재실행. NOOP 케이스 그대로인지 확인 |
+
+---
+
+## 11. git-flow
+
+- **Issue**: #76 (가설 질문) — title 영문화 + 마일스톤 `v0.5.0: LLM Router & Context-Aware Retrieval` 확인.
+- **Branch**: `feature/76-v0-5-0-polish` (현 브랜치 그대로).
+- **Commits**:
+  1. `docs(#76): add phase 9-2 validation plan`
+  2. (B) `test(#76): add rewriter NOOP regression guard` (필요 시)
+  3. (C, 필수) `fix(#76): preserve hypothetical premise in query rewriter prompt` + `test(#76): add premise preservation guards (prompt content + rewrite cleanup)`
+  4. `docs(#76): README §3/§7/§11 + phase 9-2 dev log`
+- **PR**: `feature/76-v0-5-0-polish → develop`. Assignee 작성자. 머지 권한 저장소 관리자.
+- **Release**: 본 PR 머지 후 `develop → main` 단발 머지 + `v0.5.0` 태그는 사용자 명시 지시 후에만 (release-on-demand 메모리).
+- **Hotfix**: 운영 중 발견 시 `0.x Maintenance` 마일스톤에 별도 등록.
+
+---
+
+## 12. 참고 진입점
+
+- `chat/services/question_router.py:158` — `route_question(question, history=None)` 4-tier
+- `chat/services/llm_router.py` — Phase 9-1 LLM 분류기
+- `chat/graph/nodes/router.py:28` — `route_question(state['question'], state.get('history', []))`
+- `chat/graph/nodes/agent.py:58-75` — rewriter → run_agent (S7 영향 범위)
+- `chat/services/query_rewriter.py:46` — `rewrite_query_with_history`
+- `assets/prompts/chat/query_rewriter.md` — premise 보존 1줄 + example 1건 (필수, §4)
+- `chat/tests/test_routing_e2e.py:20-36` — call-site mock 모듈 fixture
+- `chat/tests/test_pipeline_smoke.py:35-59` — `PipelineSmokeBase.setUp` (cache_clear + call-site mock)
+- `bo/views/dashboard.py:30-38` — `_PURPOSE_LABELS` (observed-only 정책 유지)
+
+---
+
+Status: Draft — Phase 9-1 머지 완료 후 검증 착수 대기


### PR DESCRIPTION
## 📋 작업 요약
- Preserve premise and ordinal context in follow-up question rewriting for v0.5.0 Phase 9-2.
- Pass the rewritten search query into the single-shot answer prompt while keeping the original user message for logs/UI.
- Add regression tests and concise Phase 9-2 documentation after automated and manual QA.

## 🔗 관련 이슈 (Related Issues)
Closes #76

## 🛠️ 작업 내용 (Changes)
- [x] Add query rewriter prompt guards for hypothetical premises and ordinal/ranking expressions.
- [x] Render both the raw question and context-aware rewritten question in single-shot prompts when they differ.
- [x] Add prompt builder and call-site regression tests for rewritten follow-up context.
- [x] Update README and Phase 9-2 plan/dev log with completed manual QA results.

## 📢 리뷰어 참고 사항 (To Reviewers)
The original user question remains preserved for UI/ChatLog. The rewritten query is only added to the LLM prompt when it differs after trimming, so NOOP rewrites keep the previous prompt shape.

Browser-generated `.playwright-mcp/` artifacts were intentionally excluded from this PR.

## ✅ 체크리스트 (Self Checklist)
- [x] 빌드(Build)가 성공적으로 수행되었는가?
- [x] 해당되는 단위 테스트(Unit Test)를 통과하였는가?
- [x] 불필요한 로그나 주석을 제거하였는가?
- [x] 프로젝트 아키텍처와 네이밍 컨벤션을 준수하였는가?
- [x] 기밀 정보(비밀번호, 키 등)가 하드코딩 되어있지 않은가?
- [x] 민감 정보(IP 주소, 포트 번호, 내부 디렉터리 구조, 파일 위치 등)가 포함되어 있지 않은가?

## 📸 스크린샷 / 테스트 로그 (Screenshots/Logs)
```text
docker compose exec -T web env OPENAI_API_KEY= python manage.py check
System check identified no issues (0 silenced).

docker compose exec -T web env OPENAI_API_KEY= python manage.py test --noinput --keepdb chat.tests.test_query_rewriter chat.tests.test_prompt_builder chat.tests.test_token_usage_purpose_call_sites
Ran 24 tests in 0.054s
OK

Additional completed validation:
- chat.tests.test_routing_e2e chat.tests.test_pipeline_smoke: Ran 32 tests, OK
- bo: Ran 30 tests, OK
- chat: Ran 569 tests, OK
- User manual QA: S1~S7 / R1~R2 passed
```
