### PR TITLE
fix: Stabilize retrieval answer accuracy for edited documents

### DIFF
--- a/assets/prompts/chat/query_rewriter.md
+++ b/assets/prompts/chat/query_rewriter.md
@@ -11,14 +11,15 @@ Rules:
 - Preserve premises and hypotheticals (e.g., "만약", "~라면", 숫자/기간 조건). Do NOT drop them — premises belong in the rewrite.
 - Preserve ordinal and ranking signals (e.g., "2번째", "두 번째", "n번째", "가장", "최대/최소", "비싼/싼", "높은/낮은"). Keep them in the rewrite — do NOT resolve them to a specific row or candidate (e.g., do NOT turn "2번째로 비싼거" into "부모 상"). Picking the actual row is the downstream retriever's / answer LLM's job; the rewrite must stay a self-contained search query.
 - Preserve exclusion / negation follow-ups (e.g., "이거 말고", "그거 말고", "다른 거", "또 있어?", "더 있을건데"). Keep the prior topic as the anchor and signal that we want OTHER items in the same category. Do NOT drop the topic and do NOT resolve to a specific row.
+- Preserve the comparison metric for comparative follow-ups. If the previous answer/table refers to monetary values (금액, 지원금액, 지급금액, 경조금, 지원금, 비용, 한도, 원), then "비싼/싼", "큰/작은", "높은/낮은" must be rewritten as monetary comparisons (e.g., "지급금액 중 가장 큰 항목"), NOT as duration ("일수", "휴가") or other axes. Always include the metric word (예: "지급금액", "경조금", "지원금액") in the rewrite so the retriever does not pick a non-monetary chunk (예: 휴가 일수 표) by mistake.
 
 Examples
 
 Conversation:
 user: 경조사 규정 알려줘
-assistant: (경조사 전체 규정을 설명…)
+assistant: (경조사 지급금액/경조금 표를 설명…)
 Current question: 비싼거
-Rewrite: 경조사 중 가장 비싼 항목
+Rewrite: 경조사 지급금액 중 가장 큰 항목
 
 Conversation:
 user: 연차는 몇 일이야?
@@ -39,9 +40,9 @@ Rewrite: 5년 근무 시 퇴직금 계산
 
 Conversation:
 user: 경조사 규정 알려줘
-assistant: (경조사 전체 표 설명…)
+assistant: (경조사 지급금액/경조금 표 설명…)
 Current question: 2번째로 비싼거
-Rewrite: 경조사 중 두 번째로 비싼 항목
+Rewrite: 경조사 지급금액 중 두 번째로 큰 항목
 
 Conversation:
 user: 경조사 규정 알려줘

--- a/chat/services/query_rewriter.py
+++ b/chat/services/query_rewriter.py
@@ -19,6 +19,7 @@ fallback:
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from chat.services.prompt_loader import load_prompt
@@ -41,6 +42,48 @@ _PROMPT_PATH = 'chat/query_rewriter.md'
 
 # 비정상적으로 긴 응답은 프롬프트 탈선으로 간주하고 버린다.
 _MAX_REWRITE_LEN = 200
+
+
+# ---------------------------------------------------------------------------
+# v0.5.4 — monetary metric guard
+#
+# 도메인 어휘/행 이름/숫자 하드코딩 없이, "금액 축으로 비교를 요청한 follow-up
+# 인지" 만 generic 단서로 판정한다. 단서가 모이면 cleaned rewrite 에 generic
+# metric phrase (`지급금액 기준`) 를 덧붙여 retriever 가 기간/일수 등 비-금액
+# chunk 로 흐르는 회귀를 차단한다.
+# ---------------------------------------------------------------------------
+
+# 가격 축 비교 신호. 부분 문자열 매칭으로 `비싼거`/`더 비싸`/`2번째로 비싼` 같은
+# 변형을 모두 포착.
+_MONETARY_COMPARATIVE_HINTS = ('비싼', '비싸', '싼거', '싼것', '저렴')
+
+# 직전 답변/표가 금전 축임을 시사하는 generic metric 단어. 도메인 어휘는 포함
+# 하지 않는다.
+_MONETARY_HISTORY_METRIC_WORDS = (
+    '금액', '지원금액', '지급금액', '지원금',
+    '비용', '한도', '단가', '가격', '요금',
+)
+
+# 금액 표기 정규식. 숫자 뒤에 단위(`만원`/`만 원`/`만`/`억원`/`억`/`원`) 가 붙은
+# 형태만 본다. 단일 문자 `원` 의 substring 매칭은 의도적으로 회피해 일반 단어
+# 안에 `원` 이 들어가는 경우의 false positive 를 막는다.
+_AMOUNT_PATTERN = re.compile(
+    r'\d[\d,\.]*\s*(?:만\s*원|만원|만|억\s*원|억원|억|원)'
+)
+
+# 이미 rewrite 가 금전 축을 명시한 경우엔 손대지 않는다.
+_MONETARY_METRIC_TOKENS_IN_REWRITE = (
+    '금액', '지급금액', '지원금액', '지원금', '비용', '한도',
+    '단가', '가격', '요금',
+)
+
+# 사용자가 명시적으로 기간/일수 축을 물은 경우엔 guard 발동 금지.
+_DURATION_AXIS_HINTS = (
+    '휴가', '일수', '며칠', '몇일', '기간', '일째', '날짜',
+)
+
+# 부착할 generic metric phrase. 회사 고유어 없음.
+_MONETARY_METRIC_SUFFIX = '지급금액 기준'
 
 
 def rewrite_query_with_history(
@@ -80,8 +123,50 @@ def rewrite_query_with_history(
         )
         return question, usage, model
 
+    cleaned = _apply_monetary_metric_guard(question, history_slice, cleaned)
+
     logger.info('쿼리 재작성: %r → %r', question, cleaned)
     return cleaned, usage, model
+
+
+def _apply_monetary_metric_guard(
+    question: str,
+    history_slice: List[Dict[str, Any]],
+    cleaned: str,
+) -> str:
+    """가격 축 follow-up 에 금액 metric 토큰이 빠져있으면 generic suffix 부착.
+
+    프롬프트가 metric 보존 규칙을 지시해도 LLM 이 흘릴 수 있어, deterministic
+    guard 로 retrieval 입력을 안정화한다. 도메인 어휘 하드코딩 없음.
+    """
+    q = (question or '').strip()
+    if not q:
+        return cleaned
+
+    # (a) 현재 질문이 가격 축 비교 follow-up 인가?
+    if not any(hint in q for hint in _MONETARY_COMPARATIVE_HINTS):
+        return cleaned
+
+    # (b) 사용자가 명시적으로 기간/휴가 축을 물었다면 guard 발동 금지.
+    if any(hint in q for hint in _DURATION_AXIS_HINTS):
+        return cleaned
+
+    # (c) 직전 history 에 금전 단위 단서가 있는가? (generic 단어 OR 금액 패턴)
+    history_blob = ' '.join(
+        (m.get('content') or '') for m in history_slice
+    )
+    has_metric_word = any(
+        word in history_blob for word in _MONETARY_HISTORY_METRIC_WORDS
+    )
+    has_amount = bool(_AMOUNT_PATTERN.search(history_blob))
+    if not (has_metric_word or has_amount):
+        return cleaned
+
+    # (d) 이미 rewrite 가 금전 metric 을 포함한다면 손대지 않는다.
+    if any(tok in cleaned for tok in _MONETARY_METRIC_TOKENS_IN_REWRITE):
+        return cleaned
+
+    return f'{cleaned} {_MONETARY_METRIC_SUFFIX}'
 
 
 # ---------------------------------------------------------------------------

--- a/chat/services/reranker.py
+++ b/chat/services/reranker.py
@@ -51,11 +51,15 @@ def rerank(question: str, candidates: List[ChunkHit], top_k: int = 5) -> List[Ch
         logger.warning('OPENAI_API_KEY 없음 → 재정렬 스킵')
         return candidates[:top_k]
 
-    # 프롬프트 구성 — 후보마다 번호 부여
+    # 프롬프트 구성 — 후보마다 번호 + 출처 메타 (v0.5.4).
+    # 동일 document 내 의미 중복 chunk 가 무작위로 정렬되는 회귀를 막기 위해
+    # LLM 에 document_name / chunk_index 를 명시한다.
     numbered = []
     for i, hit in enumerate(candidates):
         content = hit.content[:MAX_CONTENT_CHARS].replace('\n', ' ')
-        numbered.append(f'[{i}] {content}')
+        numbered.append(
+            f'[{i}] (문서: {hit.document_name}, chunk #{hit.chunk_index}) {content}'
+        )
     candidates_block = '\n\n'.join(numbered)
 
     prompt = (

--- a/chat/services/single_shot/qa_cache.py
+++ b/chat/services/single_shot/qa_cache.py
@@ -13,7 +13,6 @@ from typing import Dict, List, Optional
 from chat.models import CanonicalQA
 from chat.services.qa_retriever import QAHit, search_canonical_qa
 from chat.services.single_shot.types import QueryResult
-from files.models import Document
 
 
 logger = logging.getLogger(__name__)
@@ -42,23 +41,31 @@ def find_canonical_qa(question: str) -> List[QAHit]:
 def resolve_cache_hit(qa_hits: List[QAHit]) -> Optional[QueryResult]:
     """캐시 히트면 완성된 QueryResult 를 반환, 아니면 None.
 
-    히트 조건: 리스트가 비지 않고 top 1 유사도가 `QA_CACHE_HIT_THRESHOLD` 이상.
-    sources 는 CanonicalQA 에 기록된 document 원본을 복원한다.
+    히트 조건: 리스트가 비지 않고 top 1 유사도가 `QA_CACHE_HIT_THRESHOLD` 이상,
+    그리고 매칭된 CanonicalQA 의 `sources` 가 비어있어야 함.
+
+    v0.5.4 — sources(=Document id 목록) 가 비어있지 않은 row 는 BO 재임베딩으로
+    참조 문서의 내용이 바뀌었을 가능성이 있으므로 immediate-cache 로 답을 단락
+    시키지 않는다. 옛 답을 그대로 돌려주는 stale 응답 회귀 차단. `find_canonical_qa`
+    가 만든 QAHit 은 prompt builder 의 "과거 참고 답변" 섹션에 그대로 흐른다.
     """
     if not qa_hits or qa_hits[0].similarity < QA_CACHE_HIT_THRESHOLD:
         return None
 
     hit = qa_hits[0]
+    canonical = CanonicalQA.objects.filter(pk=hit.qa_id).first()
+
+    # sources 가 있는 row 는 cache hit 대상에서 제외 (v0.5.4).
+    if canonical is None or canonical.sources:
+        logger.info(
+            'CanonicalQA cache skip (sourced row, qa_id=%s)',
+            hit.qa_id,
+        )
+        return None
+
     logger.info('CanonicalQA 캐시 히트 (sim=%.3f, qa_id=%d)', hit.similarity, hit.qa_id)
 
-    canonical = CanonicalQA.objects.filter(pk=hit.qa_id).first()
     cached_sources: List[Dict] = []
-    if canonical and canonical.sources:
-        for d in Document.objects.filter(pk__in=canonical.sources):
-            cached_sources.append({
-                'name': d.original_name,
-                'url': d.file.url if d.file else '',
-            })
 
     return QueryResult(
         reply=hit.answer,

--- a/chat/tests/test_input_normalizer.py
+++ b/chat/tests/test_input_normalizer.py
@@ -126,3 +126,13 @@ class InputNormalizerServiceTests(TestCase):
         result = normalize('조부모상')
         self.assertTrue(result.changed)
         self.assertEqual(result.normalized, '조부모 상')
+
+    def test_contains_rule_spacing_fix_in_phrase(self):
+        # v0.5.4: phrase 안의 띄어쓰기 교정 — `조부모상 경조사비 얼마야` 처럼
+        # exact 매치는 안되지만 phrase 안에 패턴이 들어있는 케이스.
+        # contains 1건만 적용되고 즉시 종료(single best rule).
+        self._mk('조부모상', '조부모 상', match_type='contains')
+        result = normalize('조부모상 경조사비 얼마야')
+        self.assertTrue(result.changed)
+        self.assertEqual(result.normalized, '조부모 상 경조사비 얼마야')
+        self.assertEqual(len(result.applied), 1)

--- a/chat/tests/test_qa_cache_resolve.py
+++ b/chat/tests/test_qa_cache_resolve.py
@@ -1,0 +1,51 @@
+"""qa_cache.resolve_cache_hit 회귀 테스트 (v0.5.4).
+
+직접 호출. mock 없음. sourced CanonicalQA 는 immediate-cache 에서 skip,
+sources 비어있는 row 는 종전대로 cache hit.
+"""
+
+from django.test import TestCase
+
+from chat.models import CanonicalQA
+from chat.services.qa_retriever import QAHit
+from chat.services.single_shot import qa_cache
+from files.models import Document
+
+
+def _qa(answer='ANS', sources=None, embedding=None):
+    return CanonicalQA.objects.create(
+        question='q',
+        question_embedding=embedding or [0.0] * 1536,
+        answer=answer,
+        sources=sources or [],
+    )
+
+
+class ResolveCacheHitSourcedSkipTests(TestCase):
+    def test_below_threshold_returns_none(self):
+        qa = _qa()
+        hits = [QAHit(qa_id=qa.pk, question='q', answer='ANS', similarity=0.5)]
+        self.assertIsNone(qa_cache.resolve_cache_hit(hits))
+
+    def test_sourced_canonical_qa_skipped(self):
+        doc = Document.objects.create(
+            file='origin/x.txt', original_name='x.txt', size_bytes=1,
+            mime_type='text/plain', status=Document.Status.READY, edited_text='x',
+        )
+        qa = _qa(answer='OLD ANSWER', sources=[doc.id])
+        hits = [QAHit(qa_id=qa.pk, question='q', answer='OLD ANSWER', similarity=0.95)]
+        # sources 비어있지 않으므로 cache hit 반환 금지.
+        self.assertIsNone(qa_cache.resolve_cache_hit(hits))
+
+    def test_empty_sources_returns_cache_hit(self):
+        qa = _qa(answer='GENERIC ANSWER', sources=[])
+        hits = [QAHit(qa_id=qa.pk, question='q', answer='GENERIC ANSWER', similarity=0.95)]
+        result = qa_cache.resolve_cache_hit(hits)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.reply, 'GENERIC ANSWER')
+        self.assertEqual(result.total_tokens, 0)
+        self.assertIsNone(result.chat_log_id)
+        self.assertEqual(result.sources, [])
+
+    def test_empty_hits_returns_none(self):
+        self.assertIsNone(qa_cache.resolve_cache_hit([]))

--- a/chat/tests/test_query_rewriter.py
+++ b/chat/tests/test_query_rewriter.py
@@ -66,19 +66,21 @@ class QueryRewriterTests(TestCase):
         self.assertIsNone(model)
 
     def test_follow_up_uses_rewritten_query(self):
+        # 비교 follow-up 이지만 history 에 금전 단서가 없도록 다른 도메인으로 구성.
+        # (monetary metric guard 는 별도 테스트에서 검증.)
         history = [
-            {'role': 'user', 'content': '경조사 규정 알려줘'},
-            {'role': 'assistant', 'content': '경조사 규정: 본인 상 500만원, 배우자 상 100만원 ...'},
+            {'role': 'user', 'content': '연차 규정 알려줘'},
+            {'role': 'assistant', 'content': '입사 1년 11일, 2년 15일, 3년 16일 ...'},
         ]
         with patch(
             'chat.services.query_rewriter.run_chat_completion',
-            return_value=_stub_completion('경조사 중 가장 비싼 항목'),
+            return_value=_stub_completion('연차 일수가 가장 많은 연차'),
         ):
             result, usage, model = query_rewriter.rewrite_query_with_history(
-                '비싼거',
+                '제일 많은거',
                 history=history,
             )
-        self.assertEqual(result, '경조사 중 가장 비싼 항목')
+        self.assertEqual(result, '연차 일수가 가장 많은 연차')
         self.assertEqual(model, 'gpt-4o-mini')
         self.assertIsNotNone(usage)
 
@@ -151,9 +153,30 @@ class QueryRewriterPremiseTests(TestCase):
         self.assertIn('가장', prompt_text)
         # rewriter 가 후보 행을 미리 확정하지 말라는 부정 지시.
         self.assertIn('부모 상', prompt_text)
-        # Example.
+        # Example (v0.5.4 monetary metric — "비싼" 은 금액 축으로 고정).
         self.assertIn('Current question: 2번째로 비싼거', prompt_text)
-        self.assertIn('Rewrite: 경조사 중 두 번째로 비싼 항목', prompt_text)
+        self.assertIn('Rewrite: 경조사 지급금액 중 두 번째로 큰 항목', prompt_text)
+
+    def test_query_rewriter_prompt_contains_monetary_metric_rule(self):
+        """v0.5.4 — monetary comparative follow-up 은 금액 축을 보존해야 한다.
+
+        '비싼/싼/큰/작은/높은/낮은' 같은 비교 후속 질의가 휴가 일수 등 비-금액
+        chunk 로 라우팅되는 회귀(=취업규칙 출산 휴가 20일이 '비싼거' 로 잡힘)를
+        막기 위해 prompt rule + example 둘 다 박혀 있어야 한다.
+        """
+        from chat.services.prompt_loader import load_prompt
+
+        prompt_text = load_prompt('chat/query_rewriter.md')
+        # 규칙 라인.
+        self.assertIn('Preserve the comparison metric', prompt_text)
+        self.assertIn('지급금액', prompt_text)
+        self.assertIn('경조금', prompt_text)
+        # 휴가 축으로 흘리지 말라는 부정 신호.
+        self.assertIn('일수', prompt_text)
+        self.assertIn('휴가', prompt_text)
+        # `비싼거` 예제가 금액 metric 으로 재작성된다.
+        self.assertIn('Current question: 비싼거', prompt_text)
+        self.assertIn('Rewrite: 경조사 지급금액 중 가장 큰 항목', prompt_text)
 
     def test_query_rewriter_prompt_contains_exclusion_rule(self):
         """v0.5.1 plan §3 — exclusion/negation follow-up 보존 가드."""
@@ -221,6 +244,125 @@ class QueryRewriterPremiseTests(TestCase):
         self.assertIsNone(usage)
         self.assertIsNone(model)
 
+    # ------------------------------------------------------------------
+    # v0.5.4 — deterministic monetary metric guard
+    # ------------------------------------------------------------------
+
+    def _money_history(self):
+        return [
+            {'role': 'user', 'content': '경조사 규정 알려줘'},
+            {'role': 'assistant',
+             'content': '경조사 지원금액 표 — 본인 결혼 100만원, 본인 상 500만원, 배우자 상 100만원 ...'},
+        ]
+
+    def test_monetary_guard_adds_metric_suffix_when_missing(self):
+        history = self._money_history()
+        usage_stub = _stub_completion('경조사 중 가장 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('경조사 중 가장 비싼 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '비싼거?', history=history,
+            )
+        # 금액 축 토큰 보강.
+        self.assertTrue('금액' in result or '지급금액' in result)
+        # 원본 LLM 출력의 의미·ordinal·comparative 토큰 보존.
+        self.assertIn('경조사', result)
+        self.assertIn('가장', result)
+        self.assertIn('비싼', result)
+
+    def test_monetary_guard_preserves_ordinal(self):
+        history = self._money_history()
+        usage_stub = _stub_completion('경조사 중 두 번째로 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('경조사 중 두 번째로 비싼 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '2번째로 비싼거?', history=history,
+            )
+        self.assertTrue('금액' in result or '지급금액' in result)
+        self.assertIn('두 번째', result)
+        self.assertIn('비싼', result)
+
+    def test_monetary_guard_skipped_when_duration_axis_explicit(self):
+        history = self._money_history()
+        usage_stub = _stub_completion('경조사 휴가 일수 가장 긴 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('경조사 휴가 일수 가장 긴 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '휴가가 제일 긴거?', history=history,
+            )
+        # 명시적 휴가/일수 축 → 금액 metric 부착 금지.
+        self.assertNotIn('지급금액 기준', result)
+        self.assertNotIn('금액', result)
+
+    def test_monetary_guard_noop_when_rewrite_already_has_metric(self):
+        history = self._money_history()
+        usage_stub = _stub_completion('경조사 지급금액 중 가장 큰 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('경조사 지급금액 중 가장 큰 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '비싼거?', history=history,
+            )
+        # 이미 metric 이 들어있으므로 그대로.
+        self.assertEqual(result, '경조사 지급금액 중 가장 큰 항목')
+
+    def test_monetary_guard_triggers_on_amount_pattern_only_history(self):
+        # history 에 `금액` 같은 generic 단어 없이 금액 표기 패턴만 있어도 발동.
+        history = [
+            {'role': 'user', 'content': '경조사 규정 알려줘'},
+            {'role': 'assistant', 'content': '본인 결혼 100만 원, 본인 상 500만원, 부모 상 20,000원 ...'},
+        ]
+        usage_stub = _stub_completion('경조사 중 가장 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('경조사 중 가장 비싼 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '비싼거?', history=history,
+            )
+        self.assertIn('지급금액 기준', result)
+
+    def test_monetary_guard_skipped_on_false_positive_words(self):
+        # history 에 `직원/원칙/원본` 등만 있고 금액 패턴/금전 metric 단어가
+        # 없으면 발동 금지 (single-char `원` substring 매칭 회귀 방지).
+        history = [
+            {'role': 'user', 'content': '회사 정책 알려줘'},
+            {'role': 'assistant', 'content': '직원 행동 원칙 — 원본 자료는 사내 포털에 보관 ...'},
+        ]
+        usage_stub = _stub_completion('회사 정책 중 가장 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('회사 정책 중 가장 비싼 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '비싼거?', history=history,
+            )
+        self.assertNotIn('지급금액 기준', result)
+        self.assertNotIn('금액', result)
+
+    def test_monetary_guard_skipped_without_history_monetary_cue(self):
+        # history 에 금전 단서가 없으면 가격 비교 follow-up 이라도 guard 미발동.
+        history = [
+            {'role': 'user', 'content': '연차 규정 알려줘'},
+            {'role': 'assistant', 'content': '입사 1년 차 연차 일수 11일, 2년 차 15일 ...'},
+        ]
+        usage_stub = _stub_completion('연차 일수가 가장 비싼 항목')[1]
+        with patch(
+            'chat.services.query_rewriter._call_rewriter_llm',
+            return_value=('연차 일수가 가장 비싼 항목', usage_stub, 'gpt-mini'),
+        ):
+            result, _, _ = query_rewriter.rewrite_query_with_history(
+                '비싼거?', history=history,
+            )
+        self.assertNotIn('지급금액 기준', result)
+
     def test_rewrite_query_with_history_preserves_ordinal_in_cleanup(self):
         history = [
             {'role': 'user', 'content': '경조사 규정 알려줘'},
@@ -239,6 +381,11 @@ class QueryRewriterPremiseTests(TestCase):
             )
         mocked.assert_called_once()
         # cleanup pipeline 이 ordinal/ranking 토큰을 깎아먹지 않는다.
-        self.assertEqual(result, '경조사 중 두 번째로 비싼 항목')
+        # v0.5.4 — history 에 금액 패턴(`500만`) 이 있으므로 monetary guard 가
+        # `지급금액 기준` suffix 를 덧붙일 수 있다. 핵심은 ordinal/comparative
+        # 토큰이 살아있는 것.
+        self.assertIn('두 번째', result)
+        self.assertIn('비싼', result)
+        self.assertIn('경조사', result)
         self.assertIs(usage, usage_stub)
         self.assertEqual(model, 'gpt-mini')

--- a/chat/tests/test_reranker_meta.py
+++ b/chat/tests/test_reranker_meta.py
@@ -1,0 +1,90 @@
+"""reranker 메타 prepend / fallback 회귀 테스트 (v0.5.4).
+
+실제 OpenAI 호출 금지 — `chat.services.reranker.OpenAI` 를 통째로 mock.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from chat.services import reranker
+from files.services.retriever import ChunkHit
+
+
+def _hit(chunk_id, doc_name, idx, content):
+    return ChunkHit(
+        chunk_id=chunk_id,
+        document_id=chunk_id,
+        document_name=doc_name,
+        document_url='',
+        content=content,
+        score=0.1,
+        chunk_index=idx,
+    )
+
+
+def _stub_openai_client(json_payload):
+    """OpenAI() 가 반환할 client 를 흉내. chat.completions.create 한 번만 본다."""
+    client = MagicMock()
+    message = MagicMock()
+    message.content = json.dumps(json_payload)
+    choice = MagicMock()
+    choice.message = message
+    resp = MagicMock()
+    resp.choices = [choice]
+    client.chat.completions.create.return_value = resp
+    return client
+
+
+class RerankerMetaPromptTests(SimpleTestCase):
+    def test_candidate_block_includes_document_name_and_chunk_index(self):
+        hits = [
+            _hit(1, '경조사.md', 0, '본인 상 500만원'),
+            _hit(2, '연차.md', 3, '연차 일수 안내'),
+            _hit(3, '경조사.md', 7, '배우자 상 100만원'),
+        ]
+        client = _stub_openai_client({'ranking': [1, 0]})
+        with patch.dict('os.environ', {'OPENAI_API_KEY': 'sk-test'}), \
+             patch('chat.services.reranker.OpenAI', return_value=client):
+            reranker.rerank('경조사', hits, top_k=2)
+
+        # 호출 시 만들어진 prompt 본문에 메타가 prepend 되었는지.
+        kwargs = client.chat.completions.create.call_args.kwargs
+        prompt = kwargs['messages'][0]['content']
+        self.assertIn('경조사.md', prompt)
+        self.assertIn('연차.md', prompt)
+        # chunk_index 도 노출 (값은 0 / 3).
+        self.assertIn('chunk #0', prompt)
+        self.assertIn('chunk #3', prompt)
+
+
+class RerankerFallbackTests(SimpleTestCase):
+    def test_no_api_key_returns_input_truncated(self):
+        hits = [_hit(i, 'd.md', i, f'c{i}') for i in range(6)]
+        with patch.dict('os.environ', {}, clear=True):
+            out = reranker.rerank('q', hits, top_k=3)
+        self.assertEqual([h.chunk_id for h in out], [0, 1, 2])
+
+    def test_invalid_json_falls_back_to_input_order(self):
+        hits = [_hit(i, 'd.md', i, f'c{i}') for i in range(6)]
+        client = MagicMock()
+        message = MagicMock()
+        message.content = 'not-json-at-all'
+        choice = MagicMock()
+        choice.message = message
+        resp = MagicMock()
+        resp.choices = [choice]
+        client.chat.completions.create.return_value = resp
+        with patch.dict('os.environ', {'OPENAI_API_KEY': 'sk-test'}), \
+             patch('chat.services.reranker.OpenAI', return_value=client):
+            out = reranker.rerank('q', hits, top_k=3)
+        self.assertEqual([h.chunk_id for h in out], [0, 1, 2])
+
+    def test_empty_ranking_falls_back_to_input_order(self):
+        hits = [_hit(i, 'd.md', i, f'c{i}') for i in range(6)]
+        client = _stub_openai_client({'ranking': []})
+        with patch.dict('os.environ', {'OPENAI_API_KEY': 'sk-test'}), \
+             patch('chat.services.reranker.OpenAI', return_value=client):
+            out = reranker.rerank('q', hits, top_k=3)
+        self.assertEqual([h.chunk_id for h in out], [0, 1, 2])

--- a/chat/tests/test_single_shot_cache_skip.py
+++ b/chat/tests/test_single_shot_cache_skip.py
@@ -1,0 +1,108 @@
+"""run_single_shot 통합 회귀 테스트 — sourced CanonicalQA cache skip (v0.5.4).
+
+mock target 은 pipeline 의 실제 import binding 기준:
+  - chat.services.single_shot.pipeline.find_canonical_qa
+  - chat.services.single_shot.pipeline.retrieve_documents
+  - chat.services.single_shot.pipeline.run_chat_completion
+  - chat.services.single_shot.postprocess.record_token_usage
+실제 OpenAI 호출 0.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chat.models import CanonicalQA
+from chat.services.qa_retriever import QAHit
+from chat.services.single_shot import pipeline as ss_pipeline
+from files.models import Document, DocumentChunk
+from files.services.retriever import ChunkHit
+
+
+class _Usage:
+    prompt_tokens = 1
+    completion_tokens = 1
+    total_tokens = 2
+
+
+def _llm_response(text='NEW ANSWER from fresh chunk'):
+    return text, _Usage(), 'gpt-4o-mini'
+
+
+def _ready_doc(name='경조사.md'):
+    return Document.objects.create(
+        file=f'origin/{name}', original_name=name, size_bytes=1,
+        mime_type='text/markdown', status=Document.Status.READY,
+        edited_text='2000만원',
+    )
+
+
+def _ready_chunk(doc, idx=0, content='조부모 상 경조사비 2000만원'):
+    return DocumentChunk.objects.create(
+        document=doc, chunk_index=idx, content=content, embedding=[0.0] * 1536,
+    )
+
+
+class SourcedCanonicalQACacheSkipTests(TestCase):
+    def test_sourced_qa_does_not_short_circuit_and_llm_is_called(self):
+        doc = _ready_doc()
+        _ready_chunk(doc)
+        stale = CanonicalQA.objects.create(
+            question='조부모상 경조사비',
+            question_embedding=[0.0] * 1536,
+            answer='200만원',  # 옛 정답 (stale)
+            sources=[doc.id],
+        )
+        qa_hits = [QAHit(qa_id=stale.pk, question='조부모상 경조사비',
+                         answer='200만원', similarity=0.95)]
+        chunk_hit = ChunkHit(
+            chunk_id=1, document_id=doc.id, document_name=doc.original_name,
+            document_url='', content='조부모 상 경조사비 2000만원', score=0.5,
+            chunk_index=0,
+        )
+
+        with patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa',
+            return_value=qa_hits,
+        ), patch(
+            'chat.services.single_shot.pipeline.retrieve_documents',
+            return_value=[chunk_hit],
+        ), patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+            return_value=_llm_response('조부모 상 경조사비는 2000만원입니다.'),
+        ) as llm_mock, patch(
+            'chat.services.single_shot.postprocess.record_token_usage',
+        ):
+            result = ss_pipeline.run_single_shot('조부모상 경조사비', history=[])
+
+        # sourced CA 가 있어도 LLM 이 호출되고 새 답이 반환.
+        llm_mock.assert_called_once()
+        self.assertIn('2000만원', result.reply)
+
+    def test_empty_sourced_qa_still_short_circuits(self):
+        generic_qa = CanonicalQA.objects.create(
+            question='안녕',
+            question_embedding=[0.0] * 1536,
+            answer='안녕하세요',
+            sources=[],
+        )
+        qa_hits = [QAHit(qa_id=generic_qa.pk, question='안녕',
+                         answer='안녕하세요', similarity=0.95)]
+
+        with patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa',
+            return_value=qa_hits,
+        ), patch(
+            'chat.services.single_shot.pipeline.retrieve_documents',
+            return_value=[],
+        ), patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+        ) as llm_mock, patch(
+            'chat.services.single_shot.postprocess.record_token_usage',
+        ):
+            result = ss_pipeline.run_single_shot('안녕', history=[])
+
+        # sources 빈 일반답은 종전대로 cache hit → LLM 호출 없음.
+        llm_mock.assert_not_called()
+        self.assertEqual(result.reply, '안녕하세요')
+        self.assertEqual(result.total_tokens, 0)

--- a/chat/tests/test_single_shot_rewriter_retrieval.py
+++ b/chat/tests/test_single_shot_rewriter_retrieval.py
@@ -1,0 +1,116 @@
+"""run_single_shot — query_rewriter ↔ retrieve_documents 결선 회귀 테스트.
+
+Plan §7 case 8/9 — history follow-up 시 rewritten search_query 가 retrieval 까지
+전달되어야 하고, history 가 빈 첫 turn 에서는 rewriter LLM 이 호출되지 않고
+원문 그대로 retrieval 에 전달돼야 한다.
+
+mock target 은 pipeline 의 실제 import binding 기준. OpenAI 실제 호출 0.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chat.services.single_shot import pipeline as ss_pipeline
+
+
+class _Usage:
+    prompt_tokens = 1
+    completion_tokens = 1
+    total_tokens = 2
+
+
+def _llm_response(text='답변'):
+    return text, _Usage(), 'gpt-4o-mini'
+
+
+def _rewriter_response(text):
+    """`rewrite_query_with_history` 의 (search_query, usage, model) 반환."""
+    return text, _Usage(), 'gpt-4o-mini'
+
+
+class RewriterToRetrievalWiringTests(TestCase):
+    def test_followup_uses_rewritten_query_in_retrieval(self):
+        history = [
+            {'role': 'user', 'content': '경조사 규정 알려줘'},
+            {'role': 'assistant', 'content': '본인 상 500만, 배우자 상 100만 ...'},
+        ]
+        rewritten = '경조사 중 가장 비싼 항목'
+
+        with patch(
+            'chat.services.single_shot.pipeline.rewrite_query_with_history',
+            return_value=_rewriter_response(rewritten),
+        ) as rewriter_mock, patch(
+            'chat.services.single_shot.pipeline.retrieve_documents',
+            return_value=[],
+        ) as retrieve_mock, patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa',
+            return_value=[],
+        ) as find_qa_mock, patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+            return_value=_llm_response('답변'),
+        ), patch(
+            'chat.services.single_shot.postprocess.record_token_usage',
+        ):
+            ss_pipeline.run_single_shot('비싼거', history=history)
+
+        rewriter_mock.assert_called_once_with('비싼거', history)
+        # retrieve / find_qa 모두 rewritten search_query 로 호출.
+        retrieve_mock.assert_called_once_with(rewritten)
+        find_qa_mock.assert_called_once_with(rewritten)
+
+    def test_monetary_followup_rewrite_reaches_retrieval(self):
+        # v0.5.4 manual QA blocker — `비싼거` 가 휴가 일수 chunk 로 흐르는 회귀를
+        # 막기 위해, rewriter 가 `지급금액` 토큰을 포함한 self-contained 검색어를
+        # 만들면 그 문자열이 그대로 retrieve_documents 에 전달돼야 한다.
+        history = [
+            {'role': 'user', 'content': '경조사 규정 알려줘'},
+            {'role': 'assistant', 'content': '경조사 지급금액 표 — 본인 결혼 100만, 본인 상 500만 ...'},
+        ]
+        rewritten = '경조사 지급금액 중 가장 큰 항목'
+
+        with patch(
+            'chat.services.single_shot.pipeline.rewrite_query_with_history',
+            return_value=_rewriter_response(rewritten),
+        ), patch(
+            'chat.services.single_shot.pipeline.retrieve_documents',
+            return_value=[],
+        ) as retrieve_mock, patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa',
+            return_value=[],
+        ), patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+            return_value=_llm_response('답변'),
+        ), patch(
+            'chat.services.single_shot.postprocess.record_token_usage',
+        ):
+            ss_pipeline.run_single_shot('비싼거', history=history)
+
+        retrieve_mock.assert_called_once_with(rewritten)
+        # 핵심: retrieval 까지 metric 토큰이 살아 있어야 한다.
+        (called_arg,), _ = retrieve_mock.call_args
+        self.assertIn('지급금액', called_arg)
+
+    def test_empty_history_does_not_invoke_rewriter_llm(self):
+        # history 비었을 때 rewrite_query_with_history 는 원본을 그대로 반환하는
+        # 기존 fallback 을 가진다. 그 fallback 경로에서는 rewriter 가 내부적으로
+        # LLM 을 부르지 않아야 한다 (회귀 0). retrieve_documents 에는 원문이 전달.
+        with patch(
+            'chat.services.query_rewriter.run_chat_completion',
+        ) as rewriter_llm_mock, patch(
+            'chat.services.single_shot.pipeline.retrieve_documents',
+            return_value=[],
+        ) as retrieve_mock, patch(
+            'chat.services.single_shot.pipeline.find_canonical_qa',
+            return_value=[],
+        ) as find_qa_mock, patch(
+            'chat.services.single_shot.pipeline.run_chat_completion',
+            return_value=_llm_response('답변'),
+        ), patch(
+            'chat.services.single_shot.postprocess.record_token_usage',
+        ):
+            ss_pipeline.run_single_shot('비싼거', history=[])
+
+        rewriter_llm_mock.assert_not_called()
+        retrieve_mock.assert_called_once_with('비싼거')
+        find_qa_mock.assert_called_once_with('비싼거')

--- a/files/services/retriever.py
+++ b/files/services/retriever.py
@@ -4,16 +4,21 @@
 - 키워드 검색: 질문에서 뽑은 단어들로 ILIKE 매칭 + 매칭 수 기반 랭킹
 
 두 결과를 Reciprocal Rank Fusion(RRF)으로 병합해 top-K 반환.
+
+v0.5.4:
+- 후보 풀에는 `Document.status == READY` 인 chunk 만 포함.
+- 다중 키워드 동시 적중 / 질문 phrase 통째 매치는 RRF 점수에 boost 가산.
+- 최종 정렬은 score desc + chunk_id asc 로 결정적.
 """
 
 import re
 from dataclasses import dataclass
 from typing import Dict, List
 
-from django.db.models import Case, IntegerField, Q, Sum, Value, When
+from django.db.models import Case, IntegerField, Q, Value, When
 from pgvector.django import CosineDistance
 
-from files.models import DocumentChunk
+from files.models import Document, DocumentChunk
 from files.services.embedder import embed_text
 
 
@@ -26,6 +31,10 @@ KEYWORD_POOL_SIZE = 20
 
 # 최종 기본 반환 개수
 DEFAULT_TOP_K = 5
+
+# v0.5.4 — RRF 한 칸(≈1/(60+1)≈0.0164) 보다 큰 가산. 두 신호 모두 결정적.
+MULTI_KEYWORD_BOOST = 0.02   # hit_total 당 가산
+EXACT_PHRASE_BOOST = 0.05    # 질문 phrase 가 chunk 안에 통째로 들어있을 때 가산
 
 # 질문 토큰에서 제외할 조사·어미·의문사
 _STOPWORDS = {
@@ -45,6 +54,8 @@ class ChunkHit:
     document_url: str   # 원본 파일 서빙 URL (/media/origin/xxx)
     content: str
     score: float        # RRF 점수 (높을수록 관련)
+    # v0.5.4 — reranker 메타 prepend 에 사용. 기존 호출부 호환을 위해 기본값 0.
+    chunk_index: int = 0
 
 
 def search_chunks(question: str, top_k: int = DEFAULT_TOP_K) -> List[ChunkHit]:
@@ -52,60 +63,52 @@ def search_chunks(question: str, top_k: int = DEFAULT_TOP_K) -> List[ChunkHit]:
     if not question.strip():
         return []
 
+    # v0.5.4 — 후보 풀은 READY document 만.
+    ready_qs = DocumentChunk.objects.filter(
+        document__status=Document.Status.READY,
+    )
+
     # --- 1) 벡터 검색 ---
     q_vec = embed_text(question)
     vector_ids = list(
-        DocumentChunk.objects
+        ready_qs
         .annotate(distance=CosineDistance('embedding', q_vec))
-        .order_by('distance')
+        .order_by('distance', 'id')
         .values_list('id', flat=True)[:VECTOR_POOL_SIZE]
     )
 
     # --- 2) 키워드 검색 ---
     keywords = _extract_keywords(question)
     keyword_ids: List[int] = []
+    hit_total_by_id: Dict[int, int] = {}
     if keywords:
-        # Q 객체로 OR 조합 + 매칭 키워드 수로 정렬
         q_filter = Q()
         for kw in keywords:
             q_filter |= Q(content__icontains=kw)
 
-        # 각 키워드에 대해 포함 여부를 0/1로 합산 → 매칭 수
-        match_count_expr = Sum(
-            sum(
-                (
-                    Case(
-                        When(content__icontains=kw, then=Value(1)),
-                        default=Value(0),
-                        output_field=IntegerField(),
-                    )
-                    for kw in keywords
-                ),
-                start=Value(0, output_field=IntegerField()),
-            )
-        )
-        # 위 Sum은 잘못된 조합이라 간단 버전으로 대체
-        # (각 키워드별 Case를 annotate로 더함)
-        qs = DocumentChunk.objects.filter(q_filter)
+        qs = ready_qs.filter(q_filter)
+        # 각 키워드별 Case 를 annotate 로 더해 hit_total 계산.
+        from django.db.models import F
+        total_expr = None
         for i, kw in enumerate(keywords):
+            field = f'_hit_{i}'
             qs = qs.annotate(
                 **{
-                    f'_hit_{i}': Case(
+                    field: Case(
                         When(content__icontains=kw, then=Value(1)),
                         default=Value(0),
                         output_field=IntegerField(),
                     )
                 }
             )
-        # 총합을 hit_total 필드로
-        from django.db.models import F
-        total_expr = None
-        for i in range(len(keywords)):
-            col = F(f'_hit_{i}')
+            col = F(field)
             total_expr = col if total_expr is None else total_expr + col
-        qs = qs.annotate(hit_total=total_expr).order_by('-hit_total')
+        qs = qs.annotate(hit_total=total_expr).order_by('-hit_total', 'id')
 
-        keyword_ids = list(qs.values_list('id', flat=True)[:KEYWORD_POOL_SIZE])
+        for row in qs.values('id', 'hit_total')[:KEYWORD_POOL_SIZE]:
+            cid = row['id']
+            keyword_ids.append(cid)
+            hit_total_by_id[cid] = int(row['hit_total'] or 0)
 
     # --- 3) RRF 병합 ---
     rrf_scores: Dict[int, float] = {}
@@ -117,8 +120,26 @@ def search_chunks(question: str, top_k: int = DEFAULT_TOP_K) -> List[ChunkHit]:
     if not rrf_scores:
         return []
 
-    # --- 4) top_k id 뽑기 ---
-    top_ids = sorted(rrf_scores.keys(), key=lambda cid: rrf_scores[cid], reverse=True)[:top_k]
+    # --- 3.5) v0.5.4 boost — multi-keyword + exact phrase.
+    candidate_ids = list(rrf_scores.keys())
+    phrase = (question or '').strip()
+    phrase_match_by_id: Dict[int, bool] = {}
+    if phrase:
+        matched = ready_qs.filter(
+            id__in=candidate_ids, content__icontains=phrase,
+        ).values_list('id', flat=True)
+        phrase_match_by_id = {cid: True for cid in matched}
+
+    for cid in candidate_ids:
+        if hit_total_by_id.get(cid):
+            rrf_scores[cid] += MULTI_KEYWORD_BOOST * hit_total_by_id[cid]
+        if phrase_match_by_id.get(cid):
+            rrf_scores[cid] += EXACT_PHRASE_BOOST
+
+    # --- 4) 결정적 tie-break: score desc, id asc.
+    top_ids = sorted(
+        rrf_scores.keys(), key=lambda cid: (-rrf_scores[cid], cid),
+    )[:top_k]
 
     # --- 5) 객체 조회 + 순서 보존 ---
     chunks_by_id = {
@@ -137,6 +158,7 @@ def search_chunks(question: str, top_k: int = DEFAULT_TOP_K) -> List[ChunkHit]:
             document_url=c.document.file.url if c.document.file else '',
             content=c.content,
             score=rrf_scores[cid],
+            chunk_index=c.chunk_index,
         ))
     return hits
 

--- a/files/tests.py
+++ b/files/tests.py
@@ -1,3 +1,95 @@
+"""files app 회귀 테스트.
+
+v0.5.4 — `search_chunks` 의 READY 필터 / phrase boost / multi-keyword boost /
+deterministic tie-break 동작 검증. OpenAI 호출 없음 — `embed_text` 만 mock.
+"""
+
+from unittest.mock import patch
+
 from django.test import TestCase
 
-# Create your tests here.
+from files.models import Document, DocumentChunk
+from files.services import retriever
+
+
+def _fake_embed(_text):
+    # 모든 임베딩을 같은 벡터로 두면 vector 검색이 chunk id 오름차순으로 결정적.
+    return [0.0] * 1536
+
+
+def _doc(name='doc.txt', status=Document.Status.READY):
+    return Document.objects.create(
+        file=f'origin/{name}',
+        original_name=name,
+        size_bytes=10,
+        mime_type='text/plain',
+        status=status,
+        edited_text='x',
+    )
+
+
+def _chunk(doc, idx, content, embedding=None):
+    return DocumentChunk.objects.create(
+        document=doc,
+        chunk_index=idx,
+        content=content,
+        embedding=embedding or [0.0] * 1536,
+    )
+
+
+class SearchChunksReadyFilterTests(TestCase):
+    def test_non_ready_document_chunks_excluded(self):
+        ready = _doc('ready.txt', status=Document.Status.READY)
+        processing = _doc('processing.txt', status=Document.Status.PROCESSING)
+        failed = _doc('failed.txt', status=Document.Status.FAILED)
+        reviewing = _doc('reviewing.txt', status=Document.Status.REVIEWING)
+        _chunk(ready, 0, 'alpha keyword here')
+        _chunk(processing, 0, 'alpha keyword here')
+        _chunk(failed, 0, 'alpha keyword here')
+        _chunk(reviewing, 0, 'alpha keyword here')
+
+        with patch('files.services.retriever.embed_text', side_effect=_fake_embed):
+            hits = retriever.search_chunks('alpha keyword', top_k=10)
+
+        doc_ids = {h.document_id for h in hits}
+        self.assertEqual(doc_ids, {ready.id})
+
+
+class SearchChunksBoostTests(TestCase):
+    def test_multi_keyword_hit_boosts_score_above_single_hit(self):
+        # 같은 RRF 베이스라인에서 multi-keyword 매치가 single 매치보다 위에 와야 한다.
+        doc = _doc()
+        single_hit = _chunk(doc, 0, '연차 안내')
+        multi_hit = _chunk(doc, 1, '연차 휴가 안내')
+
+        with patch('files.services.retriever.embed_text', side_effect=_fake_embed):
+            hits = retriever.search_chunks('연차 휴가', top_k=2)
+
+        self.assertEqual(len(hits), 2)
+        self.assertEqual(hits[0].chunk_id, multi_hit.id)
+        self.assertEqual(hits[1].chunk_id, single_hit.id)
+
+    def test_exact_phrase_boost_promotes_phrase_match(self):
+        # phrase 가 통째로 들어있는 chunk 가 단순 키워드 매치보다 우선.
+        doc = _doc()
+        partial = _chunk(doc, 0, '경조 한도 표 참고')
+        phrase = _chunk(doc, 1, '경조사 전체 표는 다음과 같다')
+
+        with patch('files.services.retriever.embed_text', side_effect=_fake_embed):
+            hits = retriever.search_chunks('경조사', top_k=2)
+
+        self.assertEqual(hits[0].chunk_id, phrase.id)
+        self.assertIn(partial.id, [h.chunk_id for h in hits])
+
+
+class SearchChunksDeterministicTieBreakTests(TestCase):
+    def test_ties_break_by_chunk_id_ascending(self):
+        # 두 chunk 가 동일 keyword/phrase 매치로 동률이면 id ASC.
+        doc = _doc()
+        first = _chunk(doc, 0, '경조사 안내 A')
+        second = _chunk(doc, 1, '경조사 안내 B')
+
+        with patch('files.services.retriever.embed_text', side_effect=_fake_embed):
+            hits = retriever.search_chunks('경조사', top_k=2)
+
+        self.assertEqual([h.chunk_id for h in hits], [first.id, second.id])

--- a/resources/plans/v_0_x/v_0_5_4/detail/0.5.4_search_quality_stabilization_개발_플랜.md
+++ b/resources/plans/v_0_x/v_0_5_4/detail/0.5.4_search_quality_stabilization_개발_플랜.md
@@ -1,0 +1,169 @@
+# v0.5.4 검색 품질 안정화 개발 플랜
+
+- Milestone: v0.5.4: Search Quality Stabilization
+- Issue: #89 fix: Stabilize retrieval answer accuracy for edited documents
+- Branch: `feature/89-stabilize-retrieval-answer-accuracy`
+- Base: `develop`
+
+---
+
+## 1. Summary
+
+BO에서 md를 수정·재임베딩한 뒤에도 답변이 옛 값(예: 200만)으로 흔들리는 회귀를 잡는다. 핵심은 **deterministic retrieval/ranking 보강**과 **prompt-only grounding 보강**을 분리해서, 잘못된 source가 뽑힌 걸 prompt 문구로 덮지 않는 것. 현재 스키마(migration 없음) 안에서만 구현한다. 사내 용어(`조부모상` vs `조부모 상`, `경조사`)는 BO `InputNormalizationRule` 운영으로 처리하며 production 상수 하드코딩은 금지한다. 후속 질의(`비싼거`, `2번째로 비싼거`)는 `query_rewriter` + history 경로의 회귀만 보강한다.
+
+## 2. Current Symptoms
+
+- `조부모상 경조사비 얼마야?` → BO에서 2000만으로 재임베딩했음에도 200만 답변이 섞임. 옛 답을 들고 있던 `CanonicalQA` cache-hit이 새 chunk를 가린다는 가설이 가장 강함.
+- `경조사` 단독 질의 → no_sources_guard 응답. 자료엔 분명히 있음. 키워드/벡터 후보가 표 chunk를 못 끌어오거나 rerank가 떨군다.
+- `비싼거`, `2번째로 비싼거` → 직전 turn 맥락(경조사 표) 무시되고 엉뚱한 문서로 routing. `query_rewriter`가 history-blind fallback으로 가는 경로 의심.
+- `조부모상` vs `조부모 상` → 띄어쓰기 차이로 키워드 매칭/임베딩 분기. 사용자마다 답이 갈림.
+
+## 3. Root-Cause Hypotheses
+
+1. **CanonicalQA stale immediate-cache**: `single_shot/pipeline.py`는 `qa_cache.resolve_cache_hit`로 LLM 호출 없이 즉시 답을 돌려준다. BO 재임베딩으로 정답 수치가 바뀌어도 `CanonicalQA` row는 그대로 살아 있어 옛 답이 그대로 나간다.
+2. **Ranking 표현력 부족**: `files/services/retriever.py`의 `_extract_keywords`는 2글자 이상 토큰 + `_STOPWORDS` 필터만 적용. `document.status` 필터가 없어 FAILED/PROCESSING 잔존 chunk도 풀에 들어올 수 있다. exact phrase / 다중 키워드 동시 매칭에 대한 boost가 없어 표 chunk를 단독 키워드 질의(`경조사`)에서 못 끌어온다.
+3. **Rerank 누락**: `chat/services/reranker.py`는 본문만 LLM에 보낸다. `document_name`/`chunk_index` 같은 출처 신호가 없어 의미 중복 chunk가 임의로 정렬됨.
+4. **Normalization 공백**: `조부모상`/`경조사` 관련 활성 `InputNormalizationRule`이 없으면 raw 그대로 임베딩 → 표 row와 거리가 멀어진다.
+5. **Rewriter history 경로**: `query_rewriter.rewrite_query_with_history`는 history 비었거나 LLM 실패 시 원본을 반환한다. `비싼거` 같은 비자립 질의가 history-blind로 흐르는 회귀를 만들지 않는 게 중요.
+
+## 4. Scope
+
+### 4.1 Deterministic retrieval/ranking 보강 (코드, 현재 스키마)
+- `files/services/retriever.py`:
+  - 후보 풀 단계에서 `document__status=Document.Status.READY` 필터 추가.
+  - **multi-keyword boost**: 현재 keyword query는 `hit_total` annotate를 만들지만 `keyword_ids = list(qs.values_list('id', flat=True)...)`로 id만 남기고 `hit_total` 값을 버린다. 구현 시 `hit_total_by_id: Dict[int, int]` side map을 같이 채워서 RRF 병합 이후에 `rrf_scores[cid] += MULTI_KEYWORD_BOOST * hit_total_by_id.get(cid, 0)`로 가산. `order_by('-hit_total')` 변경만으로는 부족하다.
+  - **exact phrase boost**: 질문 문자열 전체(또는 정규화된 phrase)가 `content` 안에 그대로 들어 있는 chunk에 대해 `phrase_match_by_id: Dict[int, bool]` side map을 만든 뒤, RRF 병합 후 `rrf_scores[cid] += EXACT_PHRASE_BOOST`로 가산. 단독 단어 질의(`경조사`)에서 표 row가 누락되는 회귀를 막는다.
+  - **결정적 tie-break**: 최종 정렬은 `top_ids = sorted(rrf_scores.keys(), key=lambda cid: (-rrf_scores[cid], cid))[:top_k]`로 score 내림차순 + id 오름차순. RRF 동률 케이스가 매번 같은 순서로 나오도록 강제.
+  - boost 상수(`MULTI_KEYWORD_BOOST`, `EXACT_PHRASE_BOOST`)는 모듈 상단에 명명 상수로 선언. 값은 RRF 한 칸(≈ 1/(60+1) ≈ 0.0164) 차이를 넘기는 수준으로 잡되 본 플랜에서는 수치를 강제하지 않고 구현 PR에서 테스트로 정한다.
+- `chat/services/reranker.py`: 후보 본문 앞에 `[i] (문서: <document_name>, chunk #<idx>)` 메타 prepend. JSON 파싱 실패/빈 결과는 기존 fallback(`candidates[:top_k]`) 유지.
+
+### 4.2 CanonicalQA immediate-cache skip (no-migration 계약)
+- 현재 스키마 사실:
+  - `CanonicalQA.sources`는 **Document id 목록**이며 chunk PK 아님.
+  - `QAHit`은 `(qa_id, question, answer, similarity)`만 노출 — sources 없음.
+  - `Document`/`DocumentChunk`에 `updated_at`/`reembedded_at`/`created_at` 없음.
+  - 그러므로 "sources의 chunk PK 존재 검증" 또는 "최신 reembedded_at 비교"는 **migration 없이 구현 불가**.
+- 채택 계약:
+  - `qa_cache.resolve_cache_hit` 단계에서 **`CanonicalQA.sources`가 비어있지 않은 row는 immediate-cache로 반환하지 않는다**. 대신 `find_canonical_qa`의 결과는 `QAHit`으로 그대로 흘려 prompt 의 "과거 참고 답변" 섹션(`prompt_builder._render_user_content`의 `=== 과거 참고 답변 ===`)에만 사용된다.
+  - `sources`가 빈 CanonicalQA(=문서 무관 일반답)는 종전대로 immediate-cache 사용 가능.
+  - 효과: BO 재임베딩으로 회사 자료가 바뀐 뒤에는 LLM이 새 chunk를 보고 다시 답을 만들고, 옛 정답은 참고용으로만 노출된다.
+- `qa_retriever.py`/모델/마이그레이션은 건드리지 않는다. 변경 지점은 `chat/services/single_shot/qa_cache.py`의 `resolve_cache_hit` 한 곳.
+
+### 4.3 Prompt-only grounding 보강 (분리 트랙, 기본 무수정)
+- `assets/prompts/chat/source_instruction.md`에는 이미 수치/금액을 자료 그대로 인용하라는 강한 문구가 존재한다. 본 플랜에서는 **문구 중복 추가를 기본값으로 하지 않는다**.
+- §4.1/§4.2 적용 후에도 prompt-side 회귀가 남으면, 그때 최소 한 줄만 보강하는 후속 작업으로 분리한다(별도 PR/issue). 본 PR 범위에서는 손대지 않음.
+
+### 4.4 BO normalization (운영, 코드 변경 0)
+- 현재 `chat/services/input_normalizer.py::normalize()` 는 **single best rule** 정책: exact 우선 1건, 없으면 contains 1건만 적용하고 즉시 종료. 한 입력에서 여러 규칙이 동시에 적용되지 않는다.
+- 따라서 본 회귀의 1차 fixture는 `pattern='조부모상'`, `replacement='조부모 상'`, `match_type=CONTAINS` **단일 규칙**으로 좁힌다. `경조사비 → 경조사` 같은 추가 규칙은 운영자가 필요할 때 별도 priority 로 BO 에서 관리하며, 본 PR 테스트 범위에는 포함하지 않는다(동시 적용 기대 금지).
+- production code 어디에도 `'조부모상'`, `'조부모 상'`, `'경조사'`, `'비싼거'` 같은 사내 용어 상수 추가 금지.
+- 테스트 fixture 로만 동일 규칙을 생성해 검증.
+
+## 4.5 Manual-QA hotfix — monetary comparative follow-up (v0.5.4 후반)
+
+- 증상: 금액 표를 다룬 직후의 후속 비교 질의(`비싼거`, `2번째로 비싼거`)가 휴가 일수 등 비-금액 chunk 로 라우팅됨.
+- 원인: rewriter 가 만든 search query 에 금액 축 metric 토큰이 빠져 있어 retriever 가 다른 축 chunk 를 선호.
+- 본 PR 범위에서 다루지 않음 (=v0.5.5 후속):
+  - 표/섹션 단위 chunk 확장(예: 표 헤더 + 모든 행 한 chunk 로 묶기).
+  - 표 전체를 답변에 enumerate 하도록 prompt_builder 변경.
+  - retriever 가 표 chunk 를 phrase 단위로 강제 노출하는 로직.
+- 적용 계약 (현재 구현):
+  1) `assets/prompts/chat/query_rewriter.md` — monetary metric 보존 규칙을 prompt 에 명시. **보조 신호**일 뿐 정답 보장은 아님(LLM 이 흘릴 수 있음). prompt 회귀는 `test_query_rewriter_prompt_contains_monetary_metric_rule` 로 차단.
+  2) `chat/services/query_rewriter.py` — **deterministic monetary metric guard** 가 최종 안전망. 위치는 `_clean_llm_output` 직후, 반환 직전.
+- guard 발동 조건 (전부 AND):
+  (a) 현재 질문에 가격 축 비교 단서(`비싼`/`비싸`/`싼거`/`싼것`/`저렴`) 가 있고,
+  (b) 현재 질문이 명시적 기간 축(`휴가`/`일수`/`며칠`/`몇일`/`기간` 등) 을 묻지 않으며,
+  (c) 직전 history 에 금전 단서가 있고 — **generic metric 단어** 집합(`금액`/`지원금액`/`지급금액`/`지원금`/`비용`/`한도`/`단가`/`가격`/`요금`) OR **금액 표기 정규식** `\d[\d,\.]*\s*(?:만\s*원|만원|만|억\s*원|억원|억|원)` (예: `500만원`, `100만 원`, `20,000원`, `3억`),
+  (d) cleaned rewrite 에 금전 metric 토큰이 아직 없을 때.
+- 단일 문자 `원` 의 substring 매칭은 의도적으로 금지 — `직원`/`원칙`/`원본` 등 일반 단어의 false positive 회귀를 막기 위해 정규식이 숫자+단위 결합만 본다.
+- production code/상수/주석에 도메인 어휘(회사 고유 표 이름, 행 이름, 금액 등) 하드코딩 금지. guard 는 generic metric word + amount regex 만 사용한다. 도메인 시나리오는 테스트 fixture 에서만 등장.
+- 동작: 조건 모두 만족 시 rewrite 끝에 generic suffix `지급금액 기준` 부착. ordinal/comparative/topic 토큰은 LLM 출력 그대로 보존.
+- `test_monetary_followup_rewrite_reaches_retrieval` 로 metric 토큰이 `retrieve_documents` 까지 도달함을 검증. guard 단위 테스트(`test_monetary_guard_*`) 가 발동/미발동 경계와 false positive 케이스(`직원`/`원칙`/`원본`) 를 박는다.
+
+## 5. Out of Scope
+
+- 새 모델/필드/인덱스(=migration). `updated_at`/`reembedded_at` 도입은 후속.
+- 임베딩 모델/차원 변경, hybrid search 전면 교체.
+- LLM router/workflow routing 로직 변경.
+- README/CHANGELOG 갱신(릴리즈 단계).
+- BO UI 변경.
+
+## 5'. 핵심 계약
+
+### Edited-document freshness (no-migration 정의)
+- "현재 답변에 들어갈 수 있는 chunk"는 인용 시점에 `Document.status == READY` 인 chunk만(=retriever 필터로 강제).
+- 같은 document의 옛/새 chunk가 동시에 풀에 들어올 수 있는 경로는 없다(`reembed_document`가 delete-then-bulk_create, atomic). 따라서 "동일 document 내 최신 chunk 우선" 점수는 도입하지 않는다(구현 근거 없음).
+- 옛 답이 새 chunk를 가리는 실제 경로는 **CanonicalQA immediate-cache**이며, §4.2의 sourced-CA cache skip으로 차단.
+
+### Normalization 계약
+- production code 상수 금지. BO 데이터로만 운영.
+- BO에서 등록되지 않은 사내 용어는 raw 그대로 흘러가도 OK(회귀 0이 우선).
+
+### 후속 질의 (history follow-up)
+- `query_rewriter`는 history 가 있을 때만 LLM 호출. 회귀 테스트는 **history 주입 시 self-contained 검색어가 retrieve_documents 까지 전달되는지**까지만 검증.
+- history 빈 첫 turn 에서 `비싼거` 가 들어오면 원문 그대로 전달(=기존 fallback). history-blind routing 회귀 금지.
+
+## 6. Implementation Steps
+
+1. **테스트 먼저 작성** (offline, OpenAI 호출 0).
+2. `files/services/retriever.py`: READY 필터 + exact phrase boost + multi-keyword boost + 결정적 tie-break.
+3. `chat/services/reranker.py`: 후보 메타 prepend. fallback 경로 유지.
+4. `chat/services/single_shot/qa_cache.py`: `resolve_cache_hit` 에서 `sources`(Document id 목록) 비어있지 않으면 immediate-cache 스킵.
+5. `assets/prompts/chat/source_instruction.md`: **수정 없음**(기본). 후속 회귀 확인 후 별도 PR로 분리.
+6. **DB migration 없음** — 모델/필드/인덱스 변경 0.
+
+## 7. Test Plan (offline only)
+
+- 모든 테스트는 OpenAI 호출 0. mock target은 실제 import binding 기준:
+  - retriever 단위: `files.services.retriever.embed_text`
+  - reranker 단위: `chat.services.reranker.OpenAI` (또는 `chat.services.reranker.rerank` 전체 patch)
+  - rewriter 단위: `chat.services.query_rewriter.run_chat_completion`
+  - `run_single_shot` 통합: `chat.services.single_shot.pipeline.find_canonical_qa`, `chat.services.single_shot.pipeline.retrieve_documents`, `chat.services.single_shot.pipeline.run_chat_completion`, `chat.services.single_shot.postprocess.record_token_usage`
+  - cache 단위(분리, **mock 아님**): `resolve_cache_hit` 는 patch 대상이 아니라 **직접 호출하는 테스트 대상**. 실제 `CanonicalQA` row(`sources=[doc_id]` 케이스 / `sources=[]` 케이스)를 DB로 만들고, 해당 row 와 매칭되는 `QAHit` 리스트를 손으로 만들어 `resolve_cache_hit(qa_hits)` 를 직접 호출한다. 외부 호출/추가 mock 없음.
+- 케이스:
+  1. **retriever READY 필터**: PROCESSING/FAILED document의 chunk는 후보에 등장하지 않음.
+  2. **exact phrase boost**: `경조사` 단독 질의에서 표 row chunk가 top-K에 진입.
+  3. **multi-keyword boost**: 두 키워드 적중 chunk가 한 키워드 적중 chunk보다 우선.
+  4. **reranker 메타 prepend**: LLM 입력 프롬프트 안에 `(문서: ..., chunk #...)` 포함; LLM mock이 깨진 JSON을 반환하면 입력 순서 fallback.
+  5. **sourced CanonicalQA cache skip** (`qa_cache.resolve_cache_hit` 단위, DB row): `sources=[doc_id]`인 row는 immediate-cache 반환하지 않음. `sources=[]`인 row는 종전대로 반환.
+  6. **pipeline 통합**: sourced CanonicalQA 가 있더라도 `run_single_shot` 이 LLM mock 을 호출하고 새 chunk 답을 채택.
+  7. **InputNormalizationRule contains fixture**: `pattern='조부모상'`, `replacement='조부모 상'` 규칙으로 `조부모상 경조사비 얼마야` → `조부모 상 경조사비 얼마야` 로 정규화. (기존 `test_exact_rule_spacing_fix` 는 exact 매치만 커버하므로 contains 케이스를 추가.)
+  8. **rewriter history follow-up**: history 주입 시 rewriter mock 이 `경조사 중 가장 비싼 항목` 같은 self-contained 검색어 반환 → `retrieve_documents` 가 그 검색어로 호출됨.
+  9. **rewriter history-blind 회귀 0**: history 빈 첫 turn 에서 `비싼거` 가 들어오면 LLM 호출 없이 원문 그대로 retrieve.
+
+## 8. Manual QA Scenarios
+
+1. BO에서 경조사 md의 `조부모상` 금액 200만 → 2000만으로 수정·재임베딩 → 채팅에서 `조부모상 경조사비 얼마야?` → 2000만 단일 답변.
+2. 같은 세션에서 `조부모 상은?` → 동일 답변(2000만).
+3. 다른 세션에서 `경조사` 단독 → 표 인용 답변 등장(no_sources_guard 아님).
+4. 이어서 `비싼거` → 표 최고액 항목; `2번째로 비싼거` → 두 번째 항목.
+5. **BO 규칙 ON 상태**에서 `조부모상`/`조부모 상` 두 표현 모두 정답. **규칙 OFF** 상태에서는 정답 보장은 하지 않으며(=BO 운영 의존 정책), 다만 앱 오류/500 없이 일반 답변 흐름이 유지되는지 확인.
+
+## 9. Risk / Rollback
+
+- **위험**: sourced CanonicalQA immediate-cache 스킵으로 cache hit 비율 ↓, LLM 호출/비용 ↑. 단, sources 빈 CanonicalQA 는 여전히 cache hit; 운영 데이터에서 sources 가 보통 비어있지 않은 점을 감안해 모니터링 필요.
+- **위험**: reranker 메타 prepend 가 LLM 출력 포맷을 깨면 JSON 파싱 실패 → 기존 fallback 으로 자동 복귀하므로 가용성 회귀 0.
+- **위험**: retriever READY 필터로 후보가 너무 줄어 `_extract_keywords` 결과가 비는 경우 — 기존 코드에 빈 결과 가드 있음.
+- **Rollback**: 모든 변경은 함수 내부에 격리. PR 단위 revert로 충분. DB migration 없음 → down-migration 고려 불필요.
+
+## 10. File Change Summary
+
+| 영역 | 파일 | 변경 |
+|---|---|---|
+| retrieval | `files/services/retriever.py` | READY 필터 + phrase/multi-keyword boost + tie-break |
+| rerank | `chat/services/reranker.py` | 후보 메타 prepend |
+| cache | `chat/services/single_shot/qa_cache.py` | `resolve_cache_hit`에서 sourced CA immediate-skip |
+| prompt | `assets/prompts/chat/source_instruction.md` | **무수정** (후속 PR 보류) |
+| tests | `files/tests.py`, `chat/tests/test_reranker_meta.py`(신), `chat/tests/test_qa_cache_resolve.py`(신), `chat/tests/test_single_shot_cache_skip.py`(신), `chat/tests/test_input_normalizer.py`(확장), `chat/tests/test_query_rewriter.py`(확장) | 신규/확장 |
+| migration | — | **migration 없음** |
+| README/CHANGELOG | — | 본 단계 수정 금지 |
+| BO production code | — | 사내 용어 하드코딩 금지(운영 데이터만) |
+
+## 11. Definition of Done
+
+- 위 9개 offline 테스트 전부 통과(OpenAI 호출 0).
+- 수동 QA §8-1~4 통과: BO 재임베딩 후 새 수치가 단일 답변으로 반영.
+- §8-5: 규칙 ON 시 두 표현 모두 정답, OFF 시 앱 오류 없음(정답은 비보장).
+- production code 어디에도 `조부모상`/`조부모 상`/`경조사`/`비싼거` 상수 추가되지 않음(grep 검증).
+- DB migration 0건, README/CHANGELOG/`source_instruction.md` 무수정.
+- `query_rewriter` history-blind 회귀 0 — history 빈 첫 turn 에서 LLM 호출 없이 원문 그대로 전달.


### PR DESCRIPTION
## 📋 작업 요약
- Stabilize retrieval ranking so READY documents and exact/keyword matches are preferred.
- Prevent sourced QA cache rows from bypassing retrieval for edited document answers.
- Preserve monetary comparison intent in follow-up rewrites such as “비싼거?” so retrieval stays on the amount axis.

## 🔗 관련 이슈 (Related Issues)
Closes #89

## 🛠️ 작업 내용 (Changes)
- [x] Add READY-status filtering, deterministic ordering, keyword/exact boosts, and reranker metadata guards.
- [x] Add query rewriter monetary metric guard without hardcoding company-specific table rows or answer values.
- [x] Skip sourced CanonicalQA cache hits and add regression coverage for retrieval, reranking, QA cache, and follow-up rewrite behavior.

## 📢 리뷰어 참고 사항 (To Reviewers)
Manual QA confirmed the follow-up flow `경조사 알려줘` → `비싼거?` no longer drifts to leave-duration content and now keeps the comparison on 지급금액/amount 기준.

## ✅ 체크리스트 (Self Checklist)
- [x] 빌드(Build)가 성공적으로 수행되었는가?
- [x] 해당되는 단위 테스트(Unit Test)를 통과하였는가?
- [x] 불필요한 로그나 주석을 제거하였는가?
- [x] 프로젝트 아키텍처와 네이밍 컨벤션을 준수하였는가?
- [x] 기밀 정보(비밀번호, 키 등)가 하드코딩 되어있지 않은가?
- [x] 민감 정보(IP 주소, 포트 번호, 내부 디렉터리 구조, 파일 위치 등)가 포함되어 있지 않은가?

## 📸 스크린샷 / 테스트 로그 (Screenshots/Logs)
```text
python manage.py check
→ System check identified no issues (0 silenced).

python manage.py test chat.tests.test_query_rewriter chat.tests.test_single_shot_rewriter_retrieval -v 2
→ Ran 24 tests: OK

python manage.py test
→ Ran 699 tests: OK
```
